### PR TITLE
docs: Introduce a Sphinx project to document the API

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,23 @@
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Validate Documentation Builds
+        run: |
+          pip install .
+          pip install -r docs/requirements.txt
+          # At the moment there are no static assets which generates a sphinx warning
+          mkdir docs/_static
+          sphinx-build -W -b html docs docs/_build/html

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 *.egg-info
 */__pycache__/
 dist/
+
+# Sphinx documentation
+docs/_build/

--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -5,7 +5,45 @@ from .projects import Projects
 from .usage import Usage
 from typing import Union
 
+
 class Deepgram:
+    """
+    The Deepgram API client.
+
+    The client provides all the transcription, usage, key management, and project management
+    facilities. For example, to transcribe a pre-recorded file using the default API endpoint
+    of api.deepgram.com:
+
+    .. code-block::
+
+        import asyncio
+        import json
+        import deepgram
+
+        async def main():
+            client = deepgram.Deepgram("your api key")
+            with open ("path/to/file.wav", "rb") as audio:
+                source = {"buffer": audio, "mimetype": "audio/wav"}
+                options = {"punctuate": True}
+                response = client.transcription.prerecorded(source, options)
+                print(json.dumps(response, indent=4))
+
+        asyncio.run(main())
+
+    To use a self-hosted Deepgram API, specify the URL when then creating the client:
+
+    .. code-block::
+
+        client = deepgram.Deepgram({"api_key": "your api key", "api_url": "https://your.endpoint.com/"})
+
+    For details on transcription methods, refer to :class:`deepgram.transcription.Transcription`
+
+    Args:
+        options: The client configuration :class:`Options` or the Deepgram API key as a string.
+
+    Raises:
+        ValueError: If the Deepgram API URL is invalid or if the API key is missing.
+    """
     def __init__(self, options: Union[str, Options]) -> None:
         if 'api_url' in options and not options.get('api_url'):
             raise ValueError("DG: API URL must be valid or omitted")

--- a/deepgram/_types.py
+++ b/deepgram/_types.py
@@ -20,6 +20,22 @@ class UpdateResponse(TypedDict):
 # Transcription
 
 class Options(TypedDict):
+    """
+    A :class:`typing.TypedDict` of options used to build a :class:`deepgram.Deepgram` client.
+
+    .. code-block::
+
+        from deepgram import Options, Deepgram
+        options = Options(api_key="my api key", api_url="https://api.deepgram.com/v1")
+        options = Options(api_key="my other api key")  # api_url is optional if using api.deepgram.com
+        client = Deepgram(options)
+
+    Attributes:
+        api_key: The `Deepgram API key`_ used for authentication.
+        api_url: The URL of the Deepgram API.
+
+    .. _Deepgram API key: https://developers.deepgram.com/getting-started/create-api-key
+    """
     api_key: str
     api_url: Optional[str] # this URL should /not/ include a trailing slash
 

--- a/deepgram/transcription.py
+++ b/deepgram/transcription.py
@@ -99,6 +99,8 @@ class LiveTranscription:
         return LiveTranscriptionEvent
 
 class Transcription:
+    """Transcribe pre-recorded or live (streaming) audio."""
+
     def __init__(self, options: Options) -> None:
         self.options = options
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,71 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../"))
+
+import deepgram  # noqa: E402
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Deepgram Python SDK'
+copyright = '2021, devrel@deepgram.com'
+author = 'devrel@deepgram.com'
+# The X.Y version
+version = ".".join(deepgram._version.__version__.split('.')[:2])
+# The full X.Y.Z release
+release = deepgram._version.__version__
+
+# -- General configuration ---------------------------------------------------
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.doctest',
+    'sphinx.ext.intersphinx',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.githubpages',
+    'sphinx.ext.napoleon',
+    'sphinx_autodoc_typehints',
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'alabaster'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+
+# -- Extension configuration -------------------------------------------------
+
+# -- Options for intersphinx extension ---------------------------------------
+
+# Example configuration for intersphinx: refer to the Python standard library.
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3', None),
+}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,41 @@
+.. Deepgram Python SDK documentation master file, created by
+   sphinx-quickstart on Wed Sep  1 11:12:30 2021.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+===================
+Deepgram Python SDK
+===================
+
+Developer Interface
+===================
+
+This documentation covers the public interfaces the Deepgram Python SDK provides.
+
+.. note:: Documented interfaces follow `Semantic Versioning 2.0.0`_. Any interface
+          not documented here may change without incrementing the major version number.
+
+.. _semantic versioning 2.0.0: https://semver.org/
+
+
+Deepgram Client
+---------------
+
+.. autoclass:: deepgram.Deepgram
+
+
+.. autoclass:: deepgram.Options
+
+
+Transcription
+-------------
+
+.. autoclass:: deepgram.transcription.Transcription
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx-autodoc-typehints


### PR DESCRIPTION
It would be nice to have some API-level documentation for the SDK. This is a Sphinx project that introduces a single docblock and renders it to HTML with Sphinx. This can be published for human consumption via readthedocs.org, GitHub pages, or anywhere that can host the static files.

Sphinx lets you write the API documentation in the code as module, class, and function level docblocks. The RST files let you arrange these docblocks as you see fit.

This PR needs a bit more fleshing out, but before I write much more I wanted to get some feedback on if this is an approach folks like or if there are any problems with using Sphinx.