### PR TITLE
:bug: Fix urllib error handling

### DIFF
--- a/deepgram/_utils.py
+++ b/deepgram/_utils.py
@@ -144,8 +144,8 @@ def _sync_request(
                 if body.get('error'):
                     raise Exception(f'DG: {content}')
                 return body
-        except urllib.error.URLError as exc:
-            raise (Exception(f'DG: {exc}') if exc.status < 500 else exc)
+        except urllib.error.HTTPError as exc:
+            raise (Exception(f'DG: {exc}') if exc.code < 500 else exc)
 
     tries = RETRY_COUNT
     while tries > 0:


### PR DESCRIPTION
Fixes #86 - a defect where we catch urllib.error.URLError, and then introduce special handling for client errors based on the `status` attribute. URLError is a base class that is only guaranteed to have a `reason` attribute.  Instead we should be checking the subclass `HTTPError`, and using the `code` attribute to determine the status code.

The issue manifested as:

```python
Traceback (most recent call last):
 File “/d/code/tribal/tempo/test.py”, line 42, in <module>
  main()
 File “/d/code/tribal/tempo/test.py”, line 32, in main
  response = dg_client.transcription.sync_prerecorded(source, options)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File “/d/code/youtube_dump/.venv/lib/python3.11/site-packages/deepgram/transcription.py”, line 355, in sync_prerecorded
  return SyncPrerecordedTranscription(
      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 File “/d/code/youtube_dump/.venv/lib/python3.11/site-packages/deepgram/transcription.py”, line 111, in __call__
  return _sync_request(
      ^^^^^^^^^^^^^^
 File “/d/code/youtube_dump/.venv/lib/python3.11/site-packages/deepgram/_utils.py”, line 153, in _sync_request
  return attempt()
      ^^^^^^^^^
 File “/d/code/youtube_dump/.venv/lib/python3.11/site-packages/deepgram/_utils.py”, line 148, in attempt
  raise (Exception(f’DG: {exc}’) if exc.status < 500 else exc)
                   ^^^^^^^^^^
AttributeError: ‘URLError’ object has no attribute ‘status’
```