### PR TITLE
Fix PrerecordedOptions not being parsed correctly

### DIFF
--- a/deepgram/transcription.py
+++ b/deepgram/transcription.py
@@ -56,6 +56,8 @@ class PrerecordedTranscription:
             source.get('buffer', {'url': source.get('url')})
         )
         content_type = cast(str, source.get('mimetype', 'application/json'))
+        if "option" in self.transcription_options:
+            self.transcription_options = self.transcription_options["option"]
         return await _request(
             f'{self._root}{_make_query_string(self.transcription_options)}',
             self.options, method='POST', payload=payload,


### PR DESCRIPTION
If I'm 100% honest, I haven't particularly followed the Contributing Guidelines, so don't have an issue on the forum, but I noticed that Punctuation and the model was wrong, and after investigating, realised it was because the `_make_query_string` wasn't working as intended. After some debugging, I realised it was given a dictionary (as expected), but inside another dictionary.
That wrapper dictionary broke the query string builder, and this just unwraps it.