### PR TITLE
Caption enhancements - punctuation and testing

### DIFF
--- a/deepgram/extra.py
+++ b/deepgram/extra.py
@@ -50,6 +50,8 @@ class Extra:
             utterances = response["results"]["channels"][0]["alternatives"]
         captions = []
         line_counter = 1
+        if format is Caption.WEBVTT:
+            captions.append("WEBVTT")
         for utt_index, utt in enumerate(utterances):
             words = utterances[utt_index]["words"]
             word_text = "punctuated_word" if "punctuated_word" in words[0] else "word"

--- a/deepgram/extra.py
+++ b/deepgram/extra.py
@@ -52,11 +52,12 @@ class Extra:
         line_counter = 1
         for utt_index, utt in enumerate(utterances):
             words = utterances[utt_index]["words"]
+            word_text = "punctuated_word" if "punctuated_word" in words[0] else "word"
             for i in range(0, len(words), line_length):
                 start_time = words[i]["start"]
                 end_index = min(len(words) - 1, i + line_length - 1)
                 end_time = words[end_index]["end"]
-                text = " ".join([w["word"] for w in words[i:end_index + 1]])
+                text = " ".join([w[word_text] for w in words[i:end_index + 1]])
                 separator = "," if format is Caption.SRT else '.'
                 prefix = "" if format is Caption.SRT else "- "
                 caption = (

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -12,7 +12,7 @@ assert api_key, "Pass Deepgram API key as an argument: `pytest --api-key <key> t
 deepgram = Deepgram(api_key)
 
 MOCK_SRT = "1\n00:00:05,519 --> 00:00:06,019\nYep.\n\n2\n00:00:07,094 --> 00:00:08,615\nI said it before, and I'll say it\n\n3\n00:00:08,615 --> 00:00:09,115\nagain.\n\n4\n00:00:09,974 --> 00:00:11,514\nLife moves pretty fast.\n\n5\n00:00:11,974 --> 00:00:13,654\nYou don't stop and look around once in\n\n6\n00:00:13,654 --> 00:00:15,701\na while. you could miss it."
-MOCK_WEBVTT = "1\n00:00:05.519 --> 00:00:06.019\n- Yep.\n\n2\n00:00:07.094 --> 00:00:08.615\n- I said it before, and I'll say it\n\n3\n00:00:08.615 --> 00:00:09.115\n- again.\n\n4\n00:00:09.974 --> 00:00:11.514\n- Life moves pretty fast.\n\n5\n00:00:11.974 --> 00:00:13.654\n- You don't stop and look around once in\n\n6\n00:00:13.654 --> 00:00:15.701\n- a while. you could miss it."
+MOCK_WEBVTT = "WEBVTT\n\n1\n00:00:05.519 --> 00:00:06.019\n- Yep.\n\n2\n00:00:07.094 --> 00:00:08.615\n- I said it before, and I'll say it\n\n3\n00:00:08.615 --> 00:00:09.115\n- again.\n\n4\n00:00:09.974 --> 00:00:11.514\n- Life moves pretty fast.\n\n5\n00:00:11.974 --> 00:00:13.654\n- You don't stop and look around once in\n\n6\n00:00:13.654 --> 00:00:15.701\n- a while. you could miss it."
 
 """
 Happy case of captions in SRT format.

--- a/tests/test_extra.py
+++ b/tests/test_extra.py
@@ -32,5 +32,5 @@ A response without Utterances cannot be captioned.
 def test_get_SRT_no_utterances():
     response_no_utts = MOCK_RESPONSE
     del response_no_utts["results"]["utterances"]
-    with pytest.raises(AssertionError):
+    with pytest.warns(UserWarning):
         deepgram.extra.to_SRT(response_no_utts)


### PR DESCRIPTION
1) Fix test for captions without utterances - raise a UserWarning, not an AssertionError. Testing - tests pass: `pytest -T <key> tests/`

2) For caption words, use `punctuated_word` if it exists, rather than `word`, to ensure maximally-punctuated/formatted captions. This is particularly important with Whisper.

Example word info with punctuation:
```
{
	'word': "i'll",
	'start': 8.0199995,
	'end': 8.26,
	'confidence': 0.96651065,
	'punctuated_word': "I'll"
}
```

Testing:
```
response = deepgram.transcription.sync_prerecorded({"url": "https://static.deepgram.com/examples/interview_speech-analytics.wav"}, {'smart_format': True, 'model': 'nova', 'utterances': True})
deepgram.extra.to_SRT(response)

1
00:00:00,060 --> 00:00:03,659
Another big problem in the speech analytics space

2
00:00:04,500 --> 00:00:07,259
when customers first bring the software on is

3
00:00:07,259 --> 00:00:07,759
that

4
00:00:08,599 --> 00:00:09,099
they
```

```
response = deepgram.transcription.sync_prerecorded({"url": "https://static.deepgram.com/examples/interview_speech-analytics.wav"}, {'model': 'nova', 'utterances': True})
deepgram.extra.to_SRT(response)

1
00:00:00,160 --> 00:00:01,219
Another big

2
00:00:01,599 --> 00:00:03,779
problem in the speech analytics space

3
00:00:04,480 --> 00:00:07,120
when customers first bring the software on is

4
00:00:07,120 --> 00:00:08,099
that they
```

```
response = deepgram.transcription.sync_prerecorded({"url": "https://static.deepgram.com/examples/interview_speech-analytics.wav"}, {'smart_format': True, 'model': 'whisper', 'utterances': True})
deepgram.extra.to_SRT(response)

1
00:00:00,060 --> 00:00:03,659
Another big problem in the speech analytics space

2
00:00:04,500 --> 00:00:07,259
when customers first bring the software on is

3
00:00:07,259 --> 00:00:07,759
that

4
00:00:08,599 --> 00:00:09,099
they
```

EDIT:
3) Add first line `WEBVTT` to WebVTT caption files, i.e.:
```
WEBVTT

1
00:00:05.519 --> 00:00:06.019
- Another big problem in the speech analytics space
...
```