### PR TITLE
Multiple-terms Find and Replace

### DIFF
--- a/deepgram/_types.py
+++ b/deepgram/_types.py
@@ -78,7 +78,7 @@ class TranscriptionOptions(TypedDict, total=False):
     dictation: bool
     measurements: bool
     smart_format: bool
-    replace: str
+    replace: str | List[str]
     tag: List[str]
 
 
@@ -360,7 +360,7 @@ class UsageOptions(TypedDict, total=False):
     punctuate: bool
     ner: bool
     utterances: bool
-    replace: bool
+    replace: str | List[str]
     profanity_filter: bool
     keywords: bool
     diarize: bool

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -20,14 +20,14 @@ def test_transcribe_prerecorded():
     Test basic synchronous pre-recorded transcription.
     """
     response = deepgram.transcription.sync_prerecorded(
-		{
+        {
             "url": AUDIO_URL
         },
-		{
-			"model": "nova",
-			"smart_format": True,
-		},
-	)
+        {
+            "model": "nova",
+            "smart_format": True,
+        },
+    )
     actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
     assert actual_transcript == MOCK_TRANSCRIPT
 
@@ -36,15 +36,15 @@ def test_transcribe_prerecorded_find_and_replace_string():
     Test find-and-replace with a string of one term.
     """
     response = deepgram.transcription.sync_prerecorded(
-		{
+        {
             "url": AUDIO_URL
         },
-		{
-			"model": "nova",
-			"smart_format": True,
-			"replace": "fast:slow",
-		},
-	)
+        {
+            "model": "nova",
+            "smart_format": True,
+            "replace": "fast:slow",
+        },
+    )
     actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
     assert actual_transcript == MOCK_TRANSCRIPT.replace("fast", "slow")
 
@@ -53,14 +53,14 @@ def test_transcribe_prerecorded_find_and_replace_list():
     Test find-and-replace with a list of two terms.
     """
     response = deepgram.transcription.sync_prerecorded(
-		{
+        {
             "url": AUDIO_URL
         },
-		{
-			"model": "nova",
-			"smart_format": True,
-			"replace": ["fast:slow", "miss:snooze"],
-		},
-	)
+        {
+            "model": "nova",
+            "smart_format": True,
+            "replace": ["fast:slow", "miss:snooze"],
+        },
+    )
     actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
     assert actual_transcript == MOCK_TRANSCRIPT.replace("fast", "slow").replace("miss", "snooze")

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,66 @@
+import asyncio
+import json
+import pytest
+import sys
+
+# from .conftest import option
+from deepgram import Deepgram
+from .mock_response import MOCK_RESPONSE
+
+api_key = pytest.api_key
+assert api_key, "Pass Deepgram API key as an argument: `pytest --api-key <key> tests/`"
+
+deepgram = Deepgram(api_key)
+
+MOCK_TRANSCRIPT = "Yep. I said it before, and I'll say it again. Life moves pretty fast. You don't stop and look around once in a while. you could miss it."
+AUDIO_URL = "https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav"
+
+def test_transcribe_prerecorded():
+    """
+    Test basic synchronous pre-recorded transcription.
+    """
+    response = deepgram.transcription.sync_prerecorded(
+		{
+            "url": AUDIO_URL
+        },
+		{
+			"model": "nova",
+			"smart_format": True,
+		},
+	)
+    actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
+    assert actual_transcript == MOCK_TRANSCRIPT
+
+def test_transcribe_prerecorded_find_and_replace_string():
+    """
+    Test find-and-replace with a string of one term.
+    """
+    response = deepgram.transcription.sync_prerecorded(
+		{
+            "url": AUDIO_URL
+        },
+		{
+			"model": "nova",
+			"smart_format": True,
+			"replace": "fast:slow",
+		},
+	)
+    actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
+    assert actual_transcript == MOCK_TRANSCRIPT.replace("fast", "slow")
+
+def test_transcribe_prerecorded_find_and_replace_list():
+    """
+    Test find-and-replace with a list of two terms.
+    """
+    response = deepgram.transcription.sync_prerecorded(
+		{
+            "url": AUDIO_URL
+        },
+		{
+			"model": "nova",
+			"smart_format": True,
+			"replace": ["fast:slow", "miss:snooze"],
+		},
+	)
+    actual_transcript = response["results"]["channels"][0]["alternatives"][0]["transcript"]
+    assert actual_transcript == MOCK_TRANSCRIPT.replace("fast", "slow").replace("miss", "snooze")


### PR DESCRIPTION
Find and Replace accepts either a string of one term, or a list of strings of multiple terms.

This already worked, but the typing didn't indicate it.

This PR corrects the typing, and adds tests for both single-term and multiple-term Find and Replace.

```
"replace": "fast:slow",
```

OR

```
"replace": ["fast:slow", "miss:snooze"],
```