### PR TITLE
Fix build for Windows machines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ import os.path
 
 # from official Python version-detection recommendations: https://packaging.python.org/guides/single-sourcing-package-version/
 
-with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'deepgram', '_version.py')) as file:
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'deepgram', '_version.py'), encoding="utf8") as file:
     exec(file.read())
 # imports as __version__
 
-with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md')) as file:
+with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), 'README.md'), encoding="utf8") as file:
     long_description = file.read()
 
 setuptools.setup(


### PR DESCRIPTION
The wheel build uses `setup.py` to build the package - on Linux and Mac, the file read works fine, but the default encoding for Windows is different and causes a UnicodeDecodeError. This makes the encoding explicit so it works on Windows machines.