### PR TITLE
Extend multiple-term Find & Replace to <=py3.9

### DIFF
--- a/deepgram/_types.py
+++ b/deepgram/_types.py
@@ -82,7 +82,7 @@ class TranscriptionOptions(TypedDict, total=False):
     dictation: bool
     measurements: bool
     smart_format: bool
-    replace: str | List[str]
+    replace: Union[str, List[str]]
     tag: List[str]
 
 
@@ -387,7 +387,7 @@ class UsageOptions(TypedDict, total=False):
     punctuate: bool
     ner: bool
     utterances: bool
-    replace: str | List[str]
+    replace: Union[str, List[str]]
     profanity_filter: bool
     keywords: bool
     diarize: bool


### PR DESCRIPTION
Previous PR (https://github.com/deepgram/deepgram-python-sdk/pull/99) relied on the `|` union operator, which is only supported in >=py3.10. 

Existing code throws the follow error when importing `from deepgram import Deepgram` (using 3.9.17):
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "39env/lib/python3.9/site-packages/deepgram/__init__.py", line 2, in <module>
    from ._types import Options
  File "39env/lib/python3.9/site-packages/deepgram/_types.py", line 54, in <module>
    class TranscriptionOptions(TypedDict, total=False):
  File "39env/lib/python3.9/site-packages/deepgram/_types.py", line 85, in TranscriptionOptions
    replace: str | List[str]
TypeError: unsupported operand type(s) for |: 'type' and '_GenericAlias'
```

Need to rely on the `Union` operator to support 3.9 and earlier. I tested this change in 3.9 and confirmed that the Deepgram import works successfully, as does making a call against Find & Replace with multiple terms.

```
from deepgram import Deepgram
import json
import asyncio

DEEPGRAM_API_KEY = '<key>'

AUDIO_URL = 'https://static.deepgram.com/examples/Bueller-Life-moves-pretty-fast.wav'

async def main():
	dg_client = Deepgram(DEEPGRAM_API_KEY)
	response = await dg_client.transcription.prerecorded(
		{ 'url': AUDIO_URL},
		{
			"model": "nova",
			"smart_format": True,
			"replace": ["fast:slow", "miss:snooze"]
		},
	)
	print(response["results"]["channels"][0]["alternatives"][0]["transcript"])

asyncio.run(main())


Yep. I said it before, and I'll say it again. Life moves pretty slow. You don't stop and look around once in a while. you could snooze it.
```

Tests also pass - `pytest --api-key <key> tests/`