### PR TITLE
Update deprecated empty-byte close-stream

### DIFF
--- a/deepgram/transcription.py
+++ b/deepgram/transcription.py
@@ -316,7 +316,7 @@ class LiveTranscription:
         """Closes the connection to the Deepgram endpoint,
         waiting until ASR is complete on all submitted data."""
 
-        self.send(b'')  # Set message for "data is finished sending"
+        self.send(json.dumps({"type": "CloseStream"}))  # Set message for "data is finished sending"
         while not self.done:
             await asyncio.sleep(0.1)
 


### PR DESCRIPTION
Using an empty byte to close the stream is deprecated. See [docs warning message](https://developers.deepgram.com/docs/troubleshooting-websocket-data-and-net-errors-when-live-streaming-audio#closing-the-websocket-connection). Update to send the proper `{ 'type': 'CloseStream' }` websocket message when calling the `finish()` method to close a stream.

Tested and this produces no noticeable differences to the user.