### PR TITLE
Add setup section to readme to install test packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,11 +146,20 @@ In the `sample-projects` folder, there are examples from four different Python w
 
 ## Testing
 
+### Setup
+
+```
+pip install pytest
+pip install pytest-cov
+```
+
+### Run All Tests
+
 ```
 pytest --api-key <key> tests/
 ```
 
-## Test Coverage Report
+### Test Coverage Report
 
 ```
 pytest --cov=deepgram --api-key <key> tests/


### PR DESCRIPTION
I was getting the following error when trying to run the newly-documented test coverage command from https://github.com/deepgram/deepgram-python-sdk/pull/129:
```
ERROR: usage: pytest [options] [file_or_dir] [file_or_dir] [...]
pytest: error: unrecognized arguments: --cov=deepgram
  inifile: None
  rootdir: /.../deepgram-python-sdk
```

I needed to install `pytest-cov`. 

Updated the readme documentation to also specify that users should install `pytest` in order to run the tests.

We could create a top-level requirements.txt instead, but not sure if this would be undesirable to users who don't want to have external dependencies, especially for the optional purpose of running tests?