### PR TITLE
added regex validation for API key

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -14,7 +14,7 @@ from .errors import DeepgramSetupError, DeepgramApiError
 
 
 def api_key_is_valid(api_key: str) -> bool:
-    pattern = r"^[a-z0-9]{40}$"
+    pattern = r"^[a-f0-9]{40}$"
     return re.match(pattern, api_key) is not None
 
 

--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -13,9 +13,9 @@ from .extra import Extra
 from .errors import DeepgramSetupError, DeepgramApiError
 
 
-def validate_api_key(api_key: str) -> bool:
+def api_key_is_valid(api_key: str) -> bool:
     pattern = r"^[a-z0-9]{40}$"
-    re.fullmatch(pattern, api_key) is not None
+    return re.match(pattern, api_key) is not None
 
 
 class Deepgram:
@@ -29,7 +29,7 @@ class Deepgram:
 
         if "api_key" not in options:
             raise DeepgramSetupError("API key is required")
-        if not validate_api_key(options["api_key"]):
+        if not api_key_is_valid(options["api_key"]):
             raise DeepgramSetupError("Invalid API key")
 
         if "api_url" in options and options.get("api_url", None) is None:

--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -1,4 +1,5 @@
 from typing import Union
+import re
 from ._types import Options
 from .keys import Keys
 from .transcription import Transcription
@@ -12,6 +13,11 @@ from .extra import Extra
 from .errors import DeepgramSetupError, DeepgramApiError
 
 
+def validate_api_key(api_key: str) -> bool:
+    pattern = r"^[a-z0-9]{40}$"
+    re.fullmatch(pattern, api_key) is not None
+
+
 class Deepgram:
     def __init__(self, options: Union[str, Options]) -> None:
         if not isinstance(options, (str, dict)):
@@ -23,6 +29,8 @@ class Deepgram:
 
         if "api_key" not in options:
             raise DeepgramSetupError("API key is required")
+        if not validate_api_key(options["api_key"]):
+            raise DeepgramSetupError("Invalid API key")
 
         if "api_url" in options and options.get("api_url", None) is None:
             raise DeepgramSetupError("API URL must be valid or omitted")


### PR DESCRIPTION
This is a simple change to ensure the user has included an API key with the correct format.

Before this PR, if the API key was set incorrectly, the Python SDK threw a weird error SSL that was difficult to understand. This change makes it clear the issue is an invalid API key.

All tests pass.