### PR TITLE
chore: add pre-commit to check conventional commit msg

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v2.4.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: [] # optional: list of Conventional Commits types to allow e.g. [feat, fix, ci, chore, test]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,3 +8,6 @@ aiohttp
 pytest
 pytest-asyncio
 fuzzywuzzy
+
+# Lint
+pre-commit


### PR DESCRIPTION

Add pre-commit to check Conventional Commits(https://www.conventionalcommits.org/en/v1.0.0/).

To finish setup:  

1.  Run `pip install -r requirements-dev.txt`
2. Run `pre-commit install --hook-type commit-msg `