### PR TITLE
Restructure Python v3 (Part 6) - Add License Headers

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 # version
 __version__ = '0.0.0'
 

--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 import re
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 from typing import Optional

--- a/deepgram/clients/abstract_client.py
+++ b/deepgram/clients/abstract_client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 import httpx
 import json
 from typing import Dict, Any, Optional

--- a/deepgram/clients/listen.py
+++ b/deepgram/clients/listen.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from .prerecorded.client import PreRecordedClient
 from .live.client import LiveClient
 from typing import Dict, Any, Optional

--- a/deepgram/clients/live/client.py
+++ b/deepgram/clients/live/client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from .enums import LiveTranscriptionEvents
 from .helpers import convert_to_websocket_url, append_query_params
 

--- a/deepgram/clients/live/enums.py
+++ b/deepgram/clients/live/enums.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from enum import Enum
 
 class LiveTranscriptionEvents(Enum):

--- a/deepgram/clients/live/helpers.py
+++ b/deepgram/clients/live/helpers.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 
 def append_query_params(url, params=""):

--- a/deepgram/clients/live/options.py
+++ b/deepgram/clients/live/options.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from typing import Union, List, TypedDict
 
 class LiveOptions(TypedDict, total=False):

--- a/deepgram/clients/manage/client.py
+++ b/deepgram/clients/manage/client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from .response import Project, ProjectsResponse, Message, ProjectOptions, KeysResponse, Key, KeyOptions, CreateKeyResponse, MembersResponse, ScopesResponse, ScopeOptions, InvitesResponse, InviteOptions, UsageRequestsResponse, UsageRequestOptions, UsageRequest, UsageSummaryOptions, UsageSummaryResponse, UsageFieldsResponse, UsageFieldsOptions, BalancesResponse, Balance
 
 from ..abstract_client import AbstractRestfulClient

--- a/deepgram/clients/manage/response.py
+++ b/deepgram/clients/manage/response.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from datetime import datetime
 from typing import TypedDict, List, Optional, Dict
 

--- a/deepgram/clients/onprem/client.py
+++ b/deepgram/clients/onprem/client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from ..abstract_client import AbstractRestfulClient
 
 class OnPremClient(AbstractRestfulClient):

--- a/deepgram/clients/prerecorded/client.py
+++ b/deepgram/clients/prerecorded/client.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from ...errors import DeepgramError
 from ..abstract_client import AbstractRestfulClient
 

--- a/deepgram/clients/prerecorded/helpers.py
+++ b/deepgram/clients/prerecorded/helpers.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from .source import PrerecordedSource
 
 def is_buffer_source(provided_source: PrerecordedSource) -> bool:

--- a/deepgram/clients/prerecorded/options.py
+++ b/deepgram/clients/prerecorded/options.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from typing import Union, List, TypedDict
 
 class PrerecordedOptions(TypedDict, total=False):

--- a/deepgram/clients/prerecorded/response.py
+++ b/deepgram/clients/prerecorded/response.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from typing import List, Optional, TypedDict, Dict
 
 # Async Prerecorded Response Types:

--- a/deepgram/clients/prerecorded/source.py
+++ b/deepgram/clients/prerecorded/source.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from typing import Union
 from io import BufferedReader
 from typing_extensions import TypedDict

--- a/deepgram/errors.py
+++ b/deepgram/errors.py
@@ -1,3 +1,6 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
 
 class DeepgramError(Exception):
     """

--- a/deepgram/options.py
+++ b/deepgram/options.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 class DeepgramClientOptions:
 
     """

--- a/examples/demo_live.py
+++ b/examples/demo_live.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 from dotenv import load_dotenv
 import asyncio
 import aiohttp

--- a/examples/demo_manage.py
+++ b/examples/demo_manage.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 import asyncio
 import os
 from dotenv import load_dotenv

--- a/examples/demo_prerecorded.py
+++ b/examples/demo_prerecorded.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 import asyncio
 import os
 from dotenv import load_dotenv

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,7 @@
+# Copyright 2023 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
 import setuptools
 import os.path
 


### PR DESCRIPTION
This builds on this PR https://github.com/deepgram/deepgram-python-sdk/pull/156, https://github.com/deepgram/deepgram-python-sdk/pull/172, https://github.com/deepgram/deepgram-python-sdk/pull/173, https://github.com/deepgram/deepgram-python-sdk/pull/174 and https://github.com/deepgram/deepgram-python-sdk/pull/175 to restructure the project. The goal is to do this in smaller chunks so the work is not finished in this PR. The PR merges to main so the PR is going to look messy until the dependent PR is merged.

Here is a clean diff in the meantime: https://github.com/deepgram/deepgram-python-sdk/compare/dvonthenen:deepgram-python-sdk:restructure-project-part5...dvonthenen:deepgram-python-sdk:restructure-project-part6

Notable changes:
-  Just adds license to the header of each file

Verified that all existing demos work: `examples/demo_prerecorded.py`, `examples/demo_live.py`, and `examples/demo_manage.py`
