### PR TITLE
Enable Development Releases

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -1,0 +1,40 @@
+name: Development Releases
+
+on:
+    push:
+      branches:
+        - "!not_activated_on_branches!*"
+      tags:
+        - "v[0-9]+.[0-9]+.[0-9]+-dev.[0-9]+"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+          
+      - name: Update Version in __init__.py
+        run: sed -i 's/0.0.0/${{ github.ref }}/g' ./deepgram/__init__.py
+          
+      - name: Install Dependencies
+        run: pip install .
+
+      #- name: Run Tests
+      #  run: pytest tests/
+
+      - name: Install build
+        run: python -m pip install --upgrade build
+
+      - name: Build SDK
+        run: python -m build
+
+      - name: Install twine
+        run: python -m pip install --upgrade twine
+
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This introduces a GitHub workflow to publish development releases without posting an official release for dev testing. This workflow is triggered by publishing tags matching:
vX.Y.Z-dev.1, vX.Y.Z-dev.2, and so on...

This is needed in order to test packaging aspect of the SDK ahead of publishing official releases (alpha, beta, RC, ga) which can only be done by publishing to PyPi.