### PR TITLE
Fix Dev Workflow to Get Tag Name Only

### DIFF
--- a/.github/workflows/CD-dev.yml
+++ b/.github/workflows/CD-dev.yml
@@ -17,7 +17,7 @@ jobs:
           python-version: '3.10' 
           
       - name: Update Version in __init__.py
-        run: sed -i 's/0.0.0/${{ github.ref }}/g' ./deepgram/__init__.py
+        run: sed -i 's/0.0.0/${{ github.ref_name }}/g' ./deepgram/__init__.py
           
       - name: Install Dependencies
         run: pip install .


### PR DESCRIPTION
We want just the tag name `v3.0.0-dev.1` not the entire tag reference `refs/tags/v3.0.0-dev.1`.

See:
https://github.com/deepgram/deepgram-python-sdk/actions/runs/7185349071/job/19568450012