### PR TITLE
Provide Timeout Capabilities for Sync Functions

### DIFF
--- a/deepgram/clients/abstract_sync_client.py
+++ b/deepgram/clients/abstract_sync_client.py
@@ -36,32 +36,34 @@ class AbstractSyncRestClient:
 
         self.config = config
 
-    def get(self, url: str, options=None):
+    def get(self, url: str, options=None, timeout=None):
         return self._handle_request(
-            "GET", url, params=options, headers=self.config.headers
+            "GET", url, params=options, headers=self.config.headers, timeout=timeout
         )
 
-    def post(self, url: str, options=None, **kwargs):
+    def post(self, url: str, options=None, timeout=None,  **kwargs):
         return self._handle_request(
-            "POST", url, params=options, headers=self.config.headers, **kwargs
+            "POST", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
         )
 
-    def put(self, url: str, options=None, **kwargs):
+    def put(self, url: str, options=None, timeout=None, **kwargs):
         return self._handle_request(
-            "PUT", url, params=options, headers=self.config.headers, **kwargs
+            "PUT", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
         )
 
-    def patch(self, url: str, options=None, **kwargs):
+    def patch(self, url: str, options=None, timeout=None, **kwargs):
         return self._handle_request(
-            "PATCH", url, params=options, headers=self.config.headers, **kwargs
+            "PATCH", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
         )
 
-    def delete(self, url: str):
-        return self._handle_request("DELETE", url, headers=self.config.headers)
+    def delete(self, url: str, timeout=None):
+        return self._handle_request("DELETE", url, headers=self.config.headers, timeout=timeout)
 
-    def _handle_request(self, method, url, **kwargs):
+    def _handle_request(self, method, url, timeout, **kwargs):
+        if timeout is None:
+            timeout = httpx.Timeout(10.0, connect=10.0)
         try:
-            with httpx.Client() as client:
+            with httpx.Client(timeout=timeout) as client:
                 response = client.request(method, url, **kwargs)
                 response.raise_for_status()
                 return response.text

--- a/deepgram/clients/manage/v1/client.py
+++ b/deepgram/clients/manage/v1/client.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+import httpx
 import logging, verboselogs
 
 from ....options import DeepgramClientOptions
@@ -70,14 +71,14 @@ class ManageClient(AbstractSyncRestClient):
         super().__init__(config)
 
     # projects
-    def list_projects(self):
+    def list_projects(self, timeout: httpx.Timeout = None):
         return self.get_projects()
 
-    def get_projects(self):
+    def get_projects(self, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_projects ENTER")
         url = f"{self.config.url}/{self.endpoint}"
         self.logger.info("url: %s", url)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = ProjectsResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -85,12 +86,12 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_projects LEAVE")
         return res
 
-    def get_project(self, project_id: str):
+    def get_project(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Project.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -98,13 +99,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_project LEAVE")
         return res
 
-    def update_project_option(self, project_id: str, options: ProjectOptions):
+    def update_project_option(self, project_id: str, options: ProjectOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.update_project_option ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.patch(url, json=options)
+        json = self.patch(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -112,7 +113,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.update_project_option LEAVE")
         return res
 
-    def update_project(self, project_id: str, name=""):
+    def update_project(self, project_id: str, name="", timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.update_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         options: ProjectOptions = {
@@ -121,7 +122,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.patch(url, json=options)
+        json = self.patch(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -129,11 +130,11 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.update_project LEAVE")
         return res
 
-    def delete_project(self, project_id: str) -> None:
+    def delete_project(self, project_id: str, timeout: httpx.Timeout = None) -> None:
         self.logger.debug("ManageClient.delete_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         json = self.delete(url)
-        self.logger.info("json: %s", json)
+        self.logger.info("json: %s", json, timeout=timeout)
         res = Message.from_json(self.delete(url))
         self.logger.verbose("result: %s", res)
         self.logger.notice("delete_project succeeded")
@@ -141,15 +142,15 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # keys
-    def list_keys(self, project_id: str):
+    def list_keys(self, project_id: str, timeout: httpx.Timeout = None):
         return self.get_keys(project_id)
 
-    def get_keys(self, project_id: str):
+    def get_keys(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_keys ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = KeysResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -157,13 +158,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_keys LEAVE")
         return res
 
-    def get_key(self, project_id: str, key_id: str):
+    def get_key(self, project_id: str, key_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_key ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys/{key_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = KeyResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -171,13 +172,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_key LEAVE")
         return res
 
-    def create_key(self, project_id: str, options: KeyOptions):
+    def create_key(self, project_id: str, options: KeyOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.create_key ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.post(url, json=options)
+        json = self.post(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Key.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -185,13 +186,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.create_key LEAVE")
         return res
 
-    def delete_key(self, project_id: str, key_id: str) -> None:
+    def delete_key(self, project_id: str, key_id: str, timeout: httpx.Timeout = None) -> None:
         self.logger.debug("ManageClient.delete_key ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys/{key_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        json = self.delete(url)
+        json = self.delete(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -200,15 +201,15 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # members
-    def list_members(self, project_id: str):
+    def list_members(self, project_id: str, timeout: httpx.Timeout = None):
         return self.get_members(project_id)
 
-    def get_members(self, project_id: str):
+    def get_members(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_members ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/members"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = MembersResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -216,13 +217,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_members LEAVE")
         return res
 
-    def remove_member(self, project_id: str, member_id: str) -> None:
+    def remove_member(self, project_id: str, member_id: str, timeout: httpx.Timeout = None) -> None:
         self.logger.debug("ManageClient.remove_member ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/members/{member_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        json = self.delete(url)
+        json = self.delete(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -231,7 +232,7 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # scopes
-    def get_member_scopes(self, project_id: str, member_id: str):
+    def get_member_scopes(self, project_id: str, member_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_member_scopes ENTER")
         url = (
             f"{self.config.url}/{self.endpoint}/{project_id}/members/{member_id}/scopes"
@@ -239,7 +240,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = ScopesResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -248,7 +249,7 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     def update_member_scope(
-        self, project_id: str, member_id: str, options: ScopeOptions
+        self, project_id: str, member_id: str, options: ScopeOptions, timeout: httpx.Timeout = None
     ):
         self.logger.debug("ManageClient.update_member_scope ENTER")
         url = (
@@ -257,7 +258,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.put(url, json=options)
+        json = self.put(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -266,15 +267,15 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # invites
-    def list_invites(self, project_id: str):
+    def list_invites(self, project_id: str, timeout: httpx.Timeout = None):
         return self.get_invites(project_id)
 
-    def get_invites(self, project_id: str):
+    def get_invites(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_invites ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = InvitesResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -282,13 +283,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_invites LEAVE")
         return res
 
-    def send_invite_options(self, project_id: str, options: InviteOptions):
+    def send_invite_options(self, project_id: str, options: InviteOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.send_invite_options ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.post(url, json=options)
+        json = self.post(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -296,7 +297,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.send_invite_options LEAVE")
         return res
 
-    def send_invite(self, project_id: str, email: str, scope="member"):
+    def send_invite(self, project_id: str, email: str, scope="member", timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.send_invite ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites"
         options: InviteOptions = {
@@ -306,7 +307,7 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.post(url, json=options)
+        json = self.post(url, json=options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -314,13 +315,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.send_invite LEAVE")
         return res
 
-    def delete_invite(self, project_id: str, email: str):
+    def delete_invite(self, project_id: str, email: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.delete_invite ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites/{email}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("email: %s", email)
-        json = self.delete(url)
+        json = self.delete(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -328,12 +329,12 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.delete_invite LEAVE")
         return res
 
-    def leave_project(self, project_id: str):
+    def leave_project(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.leave_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/leave"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.delete(url)
+        json = self.delete(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Message.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -342,13 +343,13 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # usage
-    def get_usage_requests(self, project_id: str, options: UsageRequestOptions):
+    def get_usage_requests(self, project_id: str, options: UsageRequestOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_usage_requests ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/requests"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.get(url, options)
+        json = self.get(url, options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = UsageRequestsResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -356,13 +357,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_requests LEAVE")
         return res
 
-    def get_usage_request(self, project_id: str, request_id: str):
+    def get_usage_request(self, project_id: str, request_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_usage_request ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/requests/{request_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("request_id: %s", request_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = UsageRequest.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -370,13 +371,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_request LEAVE")
         return res
 
-    def get_usage_summary(self, project_id: str, options: UsageSummaryOptions):
+    def get_usage_summary(self, project_id: str, options: UsageSummaryOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_usage_summary ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/usage"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.get(url, options)
+        json = self.get(url, options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = UsageSummaryResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -384,13 +385,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_summary LEAVE")
         return res
 
-    def get_usage_fields(self, project_id: str, options: UsageFieldsOptions):
+    def get_usage_fields(self, project_id: str, options: UsageFieldsOptions, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_usage_fields ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/usage/fields"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = self.get(url, options)
+        json = self.get(url, options, timeout=timeout)
         self.logger.info("json: %s", json)
         res = UsageFieldsResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -399,15 +400,15 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # balances
-    def list_balances(self, project_id: str):
+    def list_balances(self, project_id: str, timeout: httpx.Timeout = None):
         return self.get_balances(project_id)
 
-    def get_balances(self, project_id: str):
+    def get_balances(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_balances ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/balances"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = BalancesResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -415,13 +416,13 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_balances LEAVE")
         return res
 
-    def get_balance(self, project_id: str, balance_id: str):
+    def get_balance(self, project_id: str, balance_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("ManageClient.get_balance ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/balances/{balance_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("balance_id: %s", balance_id)
-        json = self.get(url)
+        json = self.get(url, timeout=timeout)
         self.logger.info("json: %s", json)
         res = Balance.from_json(json)
         self.logger.verbose("result: %s", res)

--- a/deepgram/clients/onprem/v1/client.py
+++ b/deepgram/clients/onprem/v1/client.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+import httpx
 import logging, verboselogs
 
 from ...abstract_sync_client import AbstractSyncRestClient
@@ -35,50 +36,50 @@ class OnPremClient(AbstractSyncRestClient):
         self.endpoint = "v1/projects"
         super().__init__(config)
 
-    def list_onprem_credentials(self, project_id: str):
+    def list_onprem_credentials(self, project_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("OnPremClient.list_onprem_credentials ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/onprem/distribution/credentials"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        res = self.get(url)
+        res = self.get(url, timeout=timeout)
         self.logger.verbose("result: %s", res)
         self.logger.notice("list_onprem_credentials succeeded")
         self.logger.debug("OnPremClient.list_onprem_credentials LEAVE")
         return res
 
-    def get_onprem_credentials(self, project_id: str, distribution_credentials_id: str):
+    def get_onprem_credentials(self, project_id: str, distribution_credentials_id: str, timeout: httpx.Timeout = None):
         self.logger.debug("OnPremClient.get_onprem_credentials ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/onprem/distribution/credentials/{distribution_credentials_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("distribution_credentials_id: %s", distribution_credentials_id)
-        res = self.get(url)
+        res = self.get(url, timeout=timeout)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_onprem_credentials succeeded")
         self.logger.debug("OnPremClient.get_onprem_credentials LEAVE")
         return res
 
-    def create_onprem_credentials(self, project_id: str, options):
+    def create_onprem_credentials(self, project_id: str, options, timeout: httpx.Timeout = None):
         self.logger.debug("OnPremClient.create_onprem_credentials ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/onprem/distribution/credentials/"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        res = self.post(url, json=options)
+        res = self.post(url, json=options, timeout=timeout)
         self.logger.verbose("result: %s", res)
         self.logger.notice("create_onprem_credentials succeeded")
         self.logger.debug("OnPremClient.create_onprem_credentials LEAVE")
         return res
 
     def delete_onprem_credentials(
-        self, project_id: str, distribution_credentials_id: str
+        self, project_id: str, distribution_credentials_id: str, timeout: httpx.Timeout = None
     ):
         self.logger.debug("OnPremClient.delete_onprem_credentials ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}/onprem/distribution/credentials/{distribution_credentials_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("distrbution_credentials_id: %s", distribution_credentials_id)
-        res = self.delete(url)
+        res = self.delete(url, timeout=timeout)
         self.logger.verbose("result: %s", res)
         self.logger.notice("delete_onprem_credentials succeeded")
         self.logger.debug("OnPremClient.delete_onprem_credentials LEAVE")

--- a/deepgram/clients/prerecorded/v1/client.py
+++ b/deepgram/clients/prerecorded/v1/client.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+import httpx
 import logging, verboselogs
 import inspect
 
@@ -48,6 +49,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         self,
         source: UrlSource,
         options: PrerecordedOptions = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url ENTER")
@@ -70,7 +72,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = options.to_json()
-        res = PrerecordedResponse.from_json(self.post(url, options, json=body))
+        res = PrerecordedResponse.from_json(self.post(url, options, json=body, timeout=timeout))
         self.logger.verbose("result: %s", res)
         self.logger.notice("transcribe_url succeeded")
         self.logger.debug("PreRecordedClient.transcribe_url LEAVE")
@@ -99,6 +101,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         source: UrlSource,
         callback: str,
         options: PrerecordedOptions = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url_callback ENTER")
@@ -120,7 +123,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = options.to_json()
-        json = self.post(url, options, json=body)
+        json = self.post(url, options, json=body, timeout=timeout)
         self.logger.info("json: %s", json)
         res = AsyncPrerecordedResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -150,6 +153,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         self,
         source: FileSource,
         options: PrerecordedOptions = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file ENTER")
@@ -169,7 +173,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = options.to_json()
-        json = self.post(url, options, content=body)
+        json = self.post(url, options, content=body, timeout=timeout)
         self.logger.info("json: %s", json)
         res = PrerecordedResponse.from_json(json)
         self.logger.verbose("result: %s", res)
@@ -200,6 +204,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         source: FileSource,
         callback: str,
         options: PrerecordedOptions = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file_callback ENTER")
@@ -222,7 +227,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = options.to_json()
-        json = self.post(url, options, json=body)
+        json = self.post(url, options, json=body, timeout=timeout)
         self.logger.info("json: %s", json)
         res = AsyncPrerecordedResponse.from_json(json)
         self.logger.verbose("result: %s", res)


### PR DESCRIPTION
This provides the ability to set a timeout for each REST API call using the sync methods. This should correct issues with upload files for transcription but also for any REST calls where timeouts are being exceeded due to network congestion.

Verified all examples works.