### PR TITLE
[LiveClient] Pass Self in Callbacks, Make Async/Sync Client StartUp Same

### DIFF
--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -14,6 +14,7 @@ from .clients.listen import (
     AsyncPreRecordedClient,
     PrerecordedOptions,
     LiveOptions,
+    LiveTranscriptionEvents,
 )
 from .clients.onprem.client import OnPremClient
 from .clients.onprem.v1.async_client import AsyncOnPremClient

--- a/deepgram/clients/listen.py
+++ b/deepgram/clients/listen.py
@@ -12,7 +12,15 @@ from .prerecorded.client import (
     AsyncPreRecordedClient,
     PrerecordedOptions,
 )
-from .live.client import LiveClient, AsyncLiveClient, LiveOptions
+from .live.client import (
+    LiveClient,
+    AsyncLiveClient,
+    LiveOptions,
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+    LiveTranscriptionEvents,
+)
 from .errors import DeepgramModuleError
 
 

--- a/deepgram/clients/live/client.py
+++ b/deepgram/clients/live/client.py
@@ -5,6 +5,8 @@
 from .v1.client import LiveClient as LiveClientLatest
 from .v1.async_client import AsyncLiveClient as AsyncLiveClientLatest
 from .v1.options import LiveOptions as LiveOptionsLatest
+from .enums import LiveTranscriptionEvents
+from .v1.response import LiveResultResponse, MetadataResponse, ErrorResponse
 
 """
 The vX/client.py points to the current supported version in the SDK.

--- a/examples/streaming/async_http/main.py
+++ b/examples/streaming/async_http/main.py
@@ -20,44 +20,55 @@ options = LiveOptions(
 # URL for the realtime streaming audio you would like to transcribe
 URL = "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service"
 
-deepgram_api_key = os.getenv("DG_API_KEY")
-
 
 async def main():
-    deepgram = DeepgramClient(deepgram_api_key)
+    deepgram = DeepgramClient()
 
     # Create a websocket connection to Deepgram
     try:
-        dg_connection = await deepgram.listen.asynclive.v("1")(options)
+        dg_connection = deepgram.listen.asynclive.v("1")
+
+        def on_message(self, result, **kwargs):
+            if result is None:
+                return
+            sentence = result.channel.alternatives[0].transcript
+            if len(sentence) == 0:
+                return
+            print(f"speaker: {sentence}")
+
+        def on_metadata(self, metadata, **kwargs):
+            if metadata is None:
+                return
+            print(f"\n\n{metadata}\n\n")
+
+        def on_error(self, error, **kwargs):
+            if error is None:
+                return
+            print(f"\n\n{error}\n\n")
+
+        dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
+        dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+
+        # connect to websocket
+        await dg_connection.start(options)
+
+        # Send streaming audio from the URL to Deepgram
+        async with aiohttp.ClientSession() as session:
+            async with session.get(URL) as audio:
+                while True:
+                    data = await audio.content.readany()
+                    # send audio data through the socket
+                    await dg_connection.send(data)
+                    # If no data is being sent from the live stream, then break out of the loop.
+                    if not data:
+                        break
+
+        # Indicate that we've finished sending data by sending the {"type": "CloseStream"}
+        await dg_connection.finish()
     except Exception as e:
         print(f"Could not open socket: {e}")
         return
-
-    # Listen for transcripts received from Deepgram and write them to the console
-    dg_connection.on(LiveTranscriptionEvents.Transcript, print)
-
-    # Listen for metadata received from Deepgram and write to the console
-    dg_connection.on(LiveTranscriptionEvents.Metadata, print)
-
-    # Listen for the connection to close
-    dg_connection.on(
-        LiveTranscriptionEvents.Close,
-        lambda c: print(f"Connection closed with code {c}."),
-    )
-
-    # Send streaming audio from the URL to Deepgram
-    async with aiohttp.ClientSession() as session:
-        async with session.get(URL) as audio:
-            while True:
-                data = await audio.content.readany()
-                # send audio data through the socket
-                await dg_connection.send(data)
-                # If no data is being sent from the live stream, then break out of the loop.
-                if not data:
-                    break
-
-    # Indicate that we've finished sending data by sending the {"type": "CloseStream"}
-    await dg_connection.finish()
 
 
 asyncio.run(main())

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -16,6 +16,7 @@ from deepgram import (
 
 load_dotenv()
 
+
 def main():
     try:
         # example of setting up a client config
@@ -27,16 +28,9 @@ def main():
         # otherwise, use default config
         deepgram = DeepgramClient()
 
-        # Create a websocket connection to Deepgram
-        options = LiveOptions(
-            punctuate=True,
-            language="en-US",
-            encoding="linear16",
-            channels=1,
-            sample_rate=16000,
-        )
+        dg_connection = deepgram.listen.live.v("1")
 
-        def on_message(result=None):
+        def on_message(self, result, **kwargs):
             if result is None:
                 return
             sentence = result.channel.alternatives[0].transcript
@@ -44,24 +38,30 @@ def main():
                 return
             print(f"speaker: {sentence}")
 
-        def on_metadata(metadata=None):
+        def on_metadata(self, metadata, **kwargs):
             if metadata is None:
                 return
-            print(f"\n{metadata}\n")
+            print(f"\n\n{metadata}\n\n")
 
-        def on_error(error=None):
+        def on_error(self, error, **kwargs):
             if error is None:
                 return
-            print(f"\n{error}\n")
-        
-        dg_connection = deepgram.listen.live.v("1")
-        dg_connection.start(options)
+            print(f"\n\n{error}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.Error, on_error)
 
-        # create microphone
+        options = LiveOptions(
+            punctuate=True,
+            language="en-US",
+            encoding="linear16",
+            channels=1,
+            sample_rate=16000,
+        )
+        dg_connection.start(options)
+
+        # Open a microphone stream
         microphone = Microphone(dg_connection.send)
 
         # start microphone


### PR DESCRIPTION
This PR has a number of changes.

1. Pass Self in Callbacks - This is to allow for other implementations to extend the class easier and to override functions and behaviors. Also always for access to class member variables.
2. Make Async/Sync client the same - I thought there was some history in keeping the async client similar to what was implemented in v2, but I would prefer breaking the interface here than preserving the older mechanism. This keeps the Async and Sync LiveClients similar in design.
3. Added some more debug statements sync live client that were missing.
4. Simplified the example (adds on to the work done in https://github.com/deepgram/deepgram-python-sdk/pull/209

Was working on a PR to have the https://github.com/deepgram/streaming-test-suite use the Python SDK v3 and in order to get the options for transcription (vtt, srt) easier, that work would highly benefit from item 1 in this list.

Tested using: `deepgram-sdk==v3.0.0-dev.14`
Made sure all streaming examples work fine and also consumable from an external repo.