### PR TITLE
Update to Poetry Config To Breakout SDK, Dev, and Examples Dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,16 +32,19 @@ readme = "README.md"
 python = "^3.10"
 httpx = "^0.25.2"
 websockets = "^12.0"
-typing-extensions = "^4.8.0"
+typing-extensions = "^4.9.0"
 dataclasses-json = "^0.6.3"
-# python-dotenv = "^1.0.0"
 asyncio = "^3.4.3"
 aiohttp = "^3.9.1"
 verboselogs = "^1.7"
+# needed only if you are looking to use samples in the "examples" folder
 # pyaudio = "^0.2.14"
+# python-dotenv = "^1.0.0"
+# needed for contributing to the SDK
+# pytest-asyncio = "^0.21.1"
+# pytest = "^7.4.3"
+# fuzzywuzzy = "^0.18.0"
+# pytest-cov = "^4.1.0"
 
-[tool.poetry.group.dev.dependencies]
-pytest = "^7.4.3"
-pytest-asyncio = "^0.21.1"
-fuzzywuzzy = "^0.18.0"
-pytest-cov = "^4.1.0"
+# [tool.poetry.group.dev.dependencies]
+# fuzzywuzzy = "^0.18.0"


### PR DESCRIPTION
This just updates the config for those that use `poetry` to mirror the `requirements.txt`, `requirements-dev.txt`, and `requirements-example.txt`. For those that use `poetry`, only the minimum deps needed to run the SDK are enabled. For `dev` and `examples`, I have put comments on what dependencies to enable in order to run each.