### PR TITLE
Custom Query Parameters on URL for API Calls

### DIFF
--- a/deepgram/clients/abstract_async_client.py
+++ b/deepgram/clients/abstract_async_client.py
@@ -33,33 +33,62 @@ class AbstractAsyncRestClient:
         self.config = config
         self.client = httpx.AsyncClient()
 
-    async def get(self, url: str, options=None):
+    async def get(self, url: str, options=None, addons=None, **kwargs):
         return await self._handle_request(
-            "GET", url, params=options, headers=self.config.headers
+            "GET",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            **kwargs
         )
 
-    async def post(self, url: str, options=None, **kwargs):
+    async def post(self, url: str, options=None, addons=None, **kwargs):
         return await self._handle_request(
-            "POST", url, params=options, headers=self.config.headers, **kwargs
+            "POST",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            **kwargs
         )
 
-    async def put(self, url: str, options=None, **kwargs):
+    async def put(self, url: str, options=None, addons=None, **kwargs):
         return await self._handle_request(
-            "PUT", url, params=options, headers=self.config.headers, **kwargs
+            "PUT",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            **kwargs
         )
 
-    async def patch(self, url: str, options=None, **kwargs):
+    async def patch(self, url: str, options=None, addons=None, **kwargs):
         return await self._handle_request(
-            "PATCH", url, params=options, headers=self.config.headers, **kwargs
+            "PATCH",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            **kwargs
         )
 
-    async def delete(self, url: str, options=None):
-        return await self._handle_request("DELETE", url, params=options, headers=self.config.headers)
+    async def delete(self, url: str, options=None, addons=None, **kwargs):
+        return await self._handle_request(
+            "DELETE",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            **kwargs
+        )
 
-    async def _handle_request(self, method, url, params, headers, **kwargs):
+    async def _handle_request(self, method, url, params, addons, headers, **kwargs):
         new_url = url
         if params is not None:
             new_url = append_query_params(new_url, params)
+        if addons is not None:
+            new_url = append_query_params(new_url, addons)
 
         try:
             with httpx.Client() as client:

--- a/deepgram/clients/abstract_sync_client.py
+++ b/deepgram/clients/abstract_sync_client.py
@@ -34,33 +34,67 @@ class AbstractSyncRestClient:
 
         self.config = config
 
-    def get(self, url: str, options=None, timeout=None):
+    def get(self, url: str, options=None, addons=None, timeout=None, **kwargs):
         return self._handle_request(
-            "GET", url, params=options, headers=self.config.headers, timeout=timeout
+            "GET",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            timeout=timeout,
+            **kwargs
         )
 
-    def post(self, url: str, options=None, timeout=None,  **kwargs):
+    def post(self, url: str, options=None, addons=None, timeout=None, **kwargs):
         return self._handle_request(
-            "POST", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
+            "POST",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            timeout=timeout,
+            **kwargs
         )
 
-    def put(self, url: str, options=None, timeout=None, **kwargs):
+    def put(self, url: str, options=None, addons=None, timeout=None, **kwargs):
         return self._handle_request(
-            "PUT", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
+            "PUT",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            timeout=timeout,
+            **kwargs
         )
 
-    def patch(self, url: str, options=None, timeout=None, **kwargs):
+    def patch(self, url: str, options=None, addons=None, timeout=None, **kwargs):
         return self._handle_request(
-            "PATCH", url, params=options, headers=self.config.headers, timeout=timeout, **kwargs
+            "PATCH",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            timeout=timeout,
+            **kwargs
         )
 
-    def delete(self, url: str, options=None, timeout=None):
-        return self._handle_request("DELETE", url, params=options, headers=self.config.headers, timeout=timeout)
+    def delete(self, url: str, options=None, addons=None, timeout=None, **kwargs):
+        return self._handle_request(
+            "DELETE",
+            url,
+            params=options,
+            addons=addons,
+            headers=self.config.headers,
+            timeout=timeout,
+            **kwargs
+        )
 
-    def _handle_request(self, method, url, params, headers, timeout, **kwargs):
+    def _handle_request(self, method, url, params, addons, headers, timeout, **kwargs):
         new_url = url
         if params is not None:
-            new_url = append_query_params(url, params)
+            new_url = append_query_params(new_url, params)
+        if addons is not None:
+            new_url = append_query_params(new_url, addons)
 
         if timeout is None:
             timeout = httpx.Timeout(10.0, connect=10.0)

--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -39,13 +39,19 @@ class AsyncLiveClient:
         self._event_handlers = {event: [] for event in LiveTranscriptionEvents}
         self.websocket_url = convert_to_websocket_url(self.config.url, self.endpoint)
 
-    async def start(self, options: LiveOptions = None, **kwargs):
+    async def start(self, options: LiveOptions = None, addons: dict = None, **kwargs):
         self.logger.debug("AsyncLiveClient.start ENTER")
         self.logger.info("kwargs: %s", options)
+        self.logger.info("addons: %s", addons)
         self.logger.info("options: %s", kwargs)
 
         self.options = options
-        self.kwargs = kwargs
+        if addons is not None:
+            self.__dict__.update(addons)
+        if kwargs is not None:
+            self.kwargs = kwargs
+        else:
+            self.kwargs = dict()
 
         if isinstance(options, LiveOptions):
             self.logger.info("LiveOptions switching class -> json")
@@ -93,7 +99,7 @@ class AsyncLiveClient:
                         await self._emit(
                             LiveTranscriptionEvents.Transcript,
                             result=result,
-                            kwargs=self.kwargs,
+                            **dict(self.kwargs),
                         )
                     case LiveTranscriptionEvents.Metadata.value:
                         self.logger.debug(
@@ -103,7 +109,7 @@ class AsyncLiveClient:
                         await self._emit(
                             LiveTranscriptionEvents.Metadata,
                             metadata=result,
-                            kwargs=self.kwargs,
+                            **dict(self.kwargs),
                         )
                     case LiveTranscriptionEvents.Error.value:
                         self.logger.debug(
@@ -113,7 +119,7 @@ class AsyncLiveClient:
                         await self._emit(
                             LiveTranscriptionEvents.Error,
                             error=result,
-                            kwargs=self.kwargs,
+                            **dict(self.kwargs),
                         )
                     case _:
                         self.logger.error(

--- a/deepgram/clients/manage/v1/async_client.py
+++ b/deepgram/clients/manage/v1/async_client.py
@@ -59,13 +59,13 @@ class AsyncManageClient(AbstractAsyncRestClient):
         super().__init__(config)
 
     # projects
-    async def list_projects(self):
+    async def list_projects(self, addons: dict = None, **kwargs):
         """
         Please see get_projects for more information.
         """
-        return self.get_projects()
+        return self.get_projects(addons=addons, **kwargs)
 
-    async def get_projects(self):
+    async def get_projects(self, addons: dict = None, **kwargs):
         """
         Gets a list of projects for the authenticated user.
 
@@ -75,18 +75,19 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.debug("ManageClient.get_projects ENTER")
         url = f"{self.config.url}/{self.endpoint}"
         self.logger.info("url: %s", url)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = ProjectsResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = ProjectsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_projects succeeded")
         self.logger.debug("ManageClient.get_projects LEAVE")
         return res
 
-    async def get_project(self, project_id: str):
+    async def get_project(self, project_id: str, addons: dict = None, **kwargs):
         """
         Gets details for a specific project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-project
         """
@@ -94,18 +95,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = Project.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Project.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_project succeeded")
         self.logger.debug("ManageClient.get_project LEAVE")
         return res
 
-    async def update_project_option(self, project_id: str, options: ProjectOptions):
+    async def update_project_option(
+        self, project_id: str, options: ProjectOptions, addons: dict = None, **kwargs
+    ):
         """
         Updates a project's settings.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-project
         """
@@ -114,18 +118,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.patch(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.patch(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("update_project_option succeeded")
         self.logger.debug("ManageClient.update_project_option LEAVE")
         return res
 
-    async def update_project(self, project_id: str, name=""):
+    async def update_project(
+        self, project_id: str, name="", addons: dict = None, **kwargs
+    ):
         """
         Updates a project's settings.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-project
         """
@@ -137,42 +144,46 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.patch(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.patch(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("update_project succeeded")
         self.logger.debug("ManageClient.update_project LEAVE")
         return res
 
-    async def delete_project(self, project_id: str) -> None:
+    async def delete_project(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> None:
         """
         Deletes a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-project
         """
         self.logger.debug("ManageClient.delete_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
-        json = await self.delete(url)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(await self.delete(url))
+        self.logger.info("addons: %s", addons)
+        result = await self.delete(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("delete_project succeeded")
         self.logger.debug("ManageClient.delete_project LEAVE")
         return res
 
     # keys
-    async def list_keys(self, project_id: str):
+    async def list_keys(self, project_id: str, addons: dict = None, **kwargs):
         """
         Please see get_keys for more information.
         """
-        return self.get_keys(project_id)
+        return self.get_keys(project_id, addons=addons, **kwargs)
 
-    async def get_keys(self, project_id: str):
+    async def get_keys(self, project_id: str, addons: dict = None, **kwargs):
         """
         Gets a list of keys for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/list-keys
         """
@@ -180,18 +191,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = KeysResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = KeysResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_keys succeeded")
         self.logger.debug("ManageClient.get_keys LEAVE")
         return res
 
-    async def get_key(self, project_id: str, key_id: str):
+    async def get_key(
+        self, project_id: str, key_id: str, addons: dict = None, **kwargs
+    ):
         """
         Gets details for a specific key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-key
         """
@@ -200,18 +214,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = KeyResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = KeyResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_key succeeded")
         self.logger.debug("ManageClient.get_key LEAVE")
         return res
 
-    async def create_key(self, project_id: str, options: KeyOptions):
+    async def create_key(
+        self, project_id: str, options: KeyOptions, addons: dict = None, **kwargs
+    ):
         """
         Creates a new key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/create-key
         """
@@ -220,18 +237,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.post(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Key.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Key.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("create_key succeeded")
         self.logger.debug("ManageClient.create_key LEAVE")
         return res
 
-    async def delete_key(self, project_id: str, key_id: str) -> None:
+    async def delete_key(
+        self, project_id: str, key_id: str, addons: dict = None, **kwargs
+    ) -> None:
         """
         Deletes a key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-key
         """
@@ -240,25 +260,26 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        json = await self.delete(url)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.delete(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("delete_key succeeded")
         self.logger.debug("ManageClient.delete_key LEAVE")
         return res
 
     # members
-    async def list_members(self, project_id: str):
+    async def list_members(self, project_id: str, addons: dict = None, **kwargs):
         """
         Please see get_members for more information.
         """
-        return self.get_members(project_id)
+        return self.get_members(project_id, addons=addons, **kwargs)
 
-    async def get_members(self, project_id: str):
+    async def get_members(self, project_id: str, addons: dict = None, **kwargs):
         """
         Gets a list of members for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-members
         """
@@ -266,18 +287,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/members"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = MembersResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = MembersResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_members succeeded")
         self.logger.debug("ManageClient.get_members LEAVE")
         return res
 
-    async def remove_member(self, project_id: str, member_id: str) -> None:
+    async def remove_member(
+        self, project_id: str, member_id: str, addons: dict = None, **kwargs
+    ) -> None:
         """
         Removes a member from a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/remove-member
         """
@@ -286,19 +310,22 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        json = await self.delete(url)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.delete(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("remove_member succeeded")
         self.logger.debug("ManageClient.remove_member LEAVE")
         return res
 
     # scopes
-    async def get_member_scopes(self, project_id: str, member_id: str):
+    async def get_member_scopes(
+        self, project_id: str, member_id: str, addons: dict = None, **kwargs
+    ):
         """
         Gets a list of scopes for a member.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-member-scopes
         """
@@ -309,20 +336,26 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = ScopesResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = ScopesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_member_scopes succeeded")
         self.logger.debug("ManageClient.get_member_scopes LEAVE")
         return res
 
     async def update_member_scope(
-        self, project_id: str, member_id: str, options: ScopeOptions
+        self,
+        project_id: str,
+        member_id: str,
+        options: ScopeOptions,
+        addons: dict = None,
+        **kwargs,
     ):
         """
         Updates a member's scopes.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-scope
         """
@@ -333,25 +366,26 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.put(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.put(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("update_member_scope succeeded")
         self.logger.debug("ManageClient.update_member_scope LEAVE")
         return res
 
     # invites
-    async def list_invites(self, project_id: str):
+    async def list_invites(self, project_id: str, addons: dict = None, **kwargs):
         """
         Please see get_invites for more information.
         """
-        return self.get_invites(project_id)
+        return self.get_invites(project_id, addons=addons, **kwargs)
 
-    async def get_invites(self, project_id: str):
+    async def get_invites(self, project_id: str, addons: dict = None, **kwargs):
         """
         Gets a list of invites for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/list-invites
         """
@@ -359,18 +393,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = InvitesResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = InvitesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_invites succeeded")
         self.logger.debug("ManageClient.get_invites LEAVE")
         return res
 
-    async def send_invite_options(self, project_id: str, options: InviteOptions):
+    async def send_invite_options(
+        self, project_id: str, options: InviteOptions, addons: dict = None, **kwargs
+    ):
         """
         Sends an invite to a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/send-invite
         """
@@ -379,18 +416,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.post(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("send_invite_options succeeded")
         self.logger.debug("ManageClient.send_invite_options LEAVE")
         return res
 
-    async def send_invite(self, project_id: str, email: str, scope="member"):
+    async def send_invite(
+        self, project_id: str, email: str, scope="member", addons: dict = None, **kwargs
+    ):
         """
         Sends an invite to a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/send-invite
         """
@@ -403,18 +443,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.post(url, json=options)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, json=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("send_invite succeeded")
         self.logger.debug("ManageClient.send_invite LEAVE")
         return res
 
-    async def delete_invite(self, project_id: str, email: str):
+    async def delete_invite(
+        self, project_id: str, email: str, addons: dict = None, **kwargs
+    ):
         """
         Deletes an invite from a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-invite
         """
@@ -423,18 +466,19 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("email: %s", email)
-        json = await self.delete(url)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.delete(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("delete_invite succeeded")
         self.logger.debug("ManageClient.delete_invite LEAVE")
         return res
 
-    async def leave_project(self, project_id: str):
+    async def leave_project(self, project_id: str, addons: dict = None, **kwargs):
         """
         Leaves a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/leave-project
         """
@@ -442,19 +486,26 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/leave"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.delete(url)
-        self.logger.info("json: %s", json)
-        res = Message.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.delete(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("leave_project succeeded")
         self.logger.debug("ManageClient.leave_project LEAVE")
         return res
 
     # usage
-    async def get_usage_requests(self, project_id: str, options: UsageRequestOptions):
+    async def get_usage_requests(
+        self,
+        project_id: str,
+        options: UsageRequestOptions,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of usage requests for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-all-requests
         """
@@ -463,18 +514,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.get(url, options)
-        self.logger.info("json: %s", json)
-        res = UsageRequestsResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, options=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = UsageRequestsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_usage_requests succeeded")
         self.logger.debug("ManageClient.get_usage_requests LEAVE")
         return res
 
-    async def get_usage_request(self, project_id: str, request_id: str):
+    async def get_usage_request(
+        self, project_id: str, request_id: str, addons: dict = None, **kwargs
+    ):
         """
         Gets details for a specific usage request.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-request
         """
@@ -483,18 +537,25 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("request_id: %s", request_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = UsageRequest.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = UsageRequest.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_usage_request succeeded")
         self.logger.debug("ManageClient.get_usage_request LEAVE")
         return res
 
-    async def get_usage_summary(self, project_id: str, options: UsageSummaryOptions):
+    async def get_usage_summary(
+        self,
+        project_id: str,
+        options: UsageSummaryOptions,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a summary of usage for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/summarize-usage
         """
@@ -503,18 +564,25 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.get(url, options)
-        self.logger.info("json: %s", json)
-        res = UsageSummaryResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, options=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = UsageSummaryResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_usage_summary succeeded")
         self.logger.debug("ManageClient.get_usage_summary LEAVE")
         return res
 
-    async def get_usage_fields(self, project_id: str, options: UsageFieldsOptions):
+    async def get_usage_fields(
+        self,
+        project_id: str,
+        options: UsageFieldsOptions,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of usage fields for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-fields
         """
@@ -523,25 +591,26 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        json = await self.get(url, options)
-        self.logger.info("json: %s", json)
-        res = UsageFieldsResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, options=options, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = UsageFieldsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_usage_fields succeeded")
         self.logger.debug("ManageClient.get_usage_fields LEAVE")
         return res
 
     # balances
-    async def list_balances(self, project_id: str):
+    async def list_balances(self, project_id: str, addons: dict = None, **kwargs):
         """
         Please see get_balances for more information.
         """
-        return self.get_balances(project_id)
+        return self.get_balances(project_id, addons=addons, **kwargs)
 
-    async def get_balances(self, project_id: str):
+    async def get_balances(self, project_id: str, addons: dict = None, **kwargs):
         """
         Gets a list of balances for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-all-balances
         """
@@ -549,18 +618,21 @@ class AsyncManageClient(AbstractAsyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/balances"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = BalancesResponse.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = BalancesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_balances succeeded")
         self.logger.debug("ManageClient.get_balances LEAVE")
         return res
 
-    async def get_balance(self, project_id: str, balance_id: str):
+    async def get_balance(
+        self, project_id: str, balance_id: str, addons: dict = None, **kwargs
+    ):
         """
         Gets details for a specific balance.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-balance
         """
@@ -569,9 +641,10 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("balance_id: %s", balance_id)
-        json = await self.get(url)
-        self.logger.info("json: %s", json)
-        res = Balance.from_json(json)
+        self.logger.info("addons: %s", addons)
+        result = await self.get(url, addons=addons, **kwargs)
+        self.logger.info("result: %s", result)
+        res = Balance.from_json(result)
         self.logger.verbose("result: %s", res)
         self.logger.notice("get_balance succeeded")
         self.logger.debug("ManageClient.get_balance LEAVE")

--- a/deepgram/clients/manage/v1/client.py
+++ b/deepgram/clients/manage/v1/client.py
@@ -51,6 +51,7 @@ class ManageClient(AbstractSyncRestClient):
     Args:
         config (DeepgramClientOptions): all the options for the client.
     """
+
     def __init__(self, config: DeepgramClientOptions):
         self.logger = logging.getLogger(__name__)
         self.logger.addHandler(logging.StreamHandler())
@@ -61,13 +62,17 @@ class ManageClient(AbstractSyncRestClient):
         super().__init__(config)
 
     # projects
-    def list_projects(self, timeout: httpx.Timeout = None):
+    def list_projects(
+        self, timeout: httpx.Timeout = None, addons: dict = None, **kwargs
+    ):
         """
         List all projects for the current user.
         """
-        return self.get_projects()
+        return self.get_projects(timeout=timeout, addons=addons, **kwargs)
 
-    def get_projects(self, timeout: httpx.Timeout = None):
+    def get_projects(
+        self, timeout: httpx.Timeout = None, addons: dict = None, **kwargs
+    ):
         """
         Gets a list of projects for the authenticated user.
 
@@ -77,7 +82,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_projects ENTER")
         url = f"{self.config.url}/{self.endpoint}"
         self.logger.info("url: %s", url)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = ProjectsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -85,10 +91,16 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_projects LEAVE")
         return res
 
-    def get_project(self, project_id: str, timeout: httpx.Timeout = None):
+    def get_project(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets details for a specific project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-project
         """
@@ -96,7 +108,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Project.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -104,10 +117,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_project LEAVE")
         return res
 
-    def update_project_option(self, project_id: str, options: ProjectOptions, timeout: httpx.Timeout = None):
+    def update_project_option(
+        self,
+        project_id: str,
+        options: ProjectOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Updates a project's settings.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-project
         """
@@ -119,7 +139,8 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("ProjectOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.patch(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.patch(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -127,10 +148,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.update_project_option LEAVE")
         return res
 
-    def update_project(self, project_id: str, name="", timeout: httpx.Timeout = None):
+    def update_project(
+        self,
+        project_id: str,
+        name="",
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Updates a project's settings.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-project
         """
@@ -142,7 +170,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        result = self.patch(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.patch(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -150,16 +179,23 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.update_project LEAVE")
         return res
 
-    def delete_project(self, project_id: str, timeout: httpx.Timeout = None) -> None:
+    def delete_project(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ) -> None:
         """
         Deletes a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-project
         """
         self.logger.debug("ManageClient.delete_project ENTER")
         url = f"{self.config.url}/{self.endpoint}/{project_id}"
-        result = self.delete(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.delete(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -168,16 +204,28 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # keys
-    def list_keys(self, project_id: str, timeout: httpx.Timeout = None):
+    def list_keys(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Please see get_keys for more information.
         """
-        return self.get_keys(project_id)
+        return self.get_keys(project_id, timeout=timeout, addons=addons, **kwargs)
 
-    def get_keys(self, project_id: str, timeout: httpx.Timeout = None):
+    def get_keys(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of keys for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/list-keys
         """
@@ -185,7 +233,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/keys"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = KeysResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -193,10 +242,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_keys LEAVE")
         return res
 
-    def get_key(self, project_id: str, key_id: str, timeout: httpx.Timeout = None):
+    def get_key(
+        self,
+        project_id: str,
+        key_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets details for a specific key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-key
         """
@@ -205,7 +261,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = KeyResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -213,10 +270,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_key LEAVE")
         return res
 
-    def create_key(self, project_id: str, options: KeyOptions, timeout: httpx.Timeout = None):
+    def create_key(
+        self,
+        project_id: str,
+        options: KeyOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Creates a new key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/create-key
         """
@@ -228,7 +292,8 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("KeyOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.post(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.post(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Key.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -236,10 +301,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.create_key LEAVE")
         return res
 
-    def delete_key(self, project_id: str, key_id: str, timeout: httpx.Timeout = None) -> None:
+    def delete_key(
+        self,
+        project_id: str,
+        key_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ) -> None:
         """
         Deletes a key.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-key
         """
@@ -248,7 +320,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("key_id: %s", key_id)
-        result = self.delete(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.delete(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -257,16 +330,28 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # members
-    def list_members(self, project_id: str, timeout: httpx.Timeout = None):
+    def list_members(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Please see get_members for more information.
         """
-        return self.get_members(project_id)
+        return self.get_members(project_id, timeout=timeout, addons=addons, **kwargs)
 
-    def get_members(self, project_id: str, timeout: httpx.Timeout = None):
+    def get_members(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of members for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-members
         """
@@ -274,7 +359,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/members"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = MembersResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -282,10 +368,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_members LEAVE")
         return res
 
-    def remove_member(self, project_id: str, member_id: str, timeout: httpx.Timeout = None) -> None:
+    def remove_member(
+        self,
+        project_id: str,
+        member_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ) -> None:
         """
         Removes a member from a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/remove-member
         """
@@ -294,7 +387,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        result = self.delete(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.delete(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -303,10 +397,17 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # scopes
-    def get_member_scopes(self, project_id: str, member_id: str, timeout: httpx.Timeout = None):
+    def get_member_scopes(
+        self,
+        project_id: str,
+        member_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of scopes for a member.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-member-scopes
         """
@@ -317,7 +418,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("member_id: %s", member_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = ScopesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -326,11 +428,17 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     def update_member_scope(
-        self, project_id: str, member_id: str, options: ScopeOptions, timeout: httpx.Timeout = None
+        self,
+        project_id: str,
+        member_id: str,
+        options: ScopeOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
     ):
         """
         Updates a member's scopes.
-        
+
         Reference:
         https://developers.deepgram.com/reference/update-scope
         """
@@ -344,7 +452,8 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("ScopeOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.put(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.put(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -353,16 +462,28 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # invites
-    def list_invites(self, project_id: str, timeout: httpx.Timeout = None):
+    def list_invites(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Please see get_invites for more information.
         """
-        return self.get_invites(project_id)
+        return self.get_invites(project_id, timeout=timeout, addons=addons, **kwargs)
 
-    def get_invites(self, project_id: str, timeout: httpx.Timeout = None):
+    def get_invites(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of invites for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/list-invites
         """
@@ -370,7 +491,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/invites"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = InvitesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -378,10 +500,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_invites LEAVE")
         return res
 
-    def send_invite_options(self, project_id: str, options: InviteOptions, timeout: httpx.Timeout = None):
+    def send_invite_options(
+        self,
+        project_id: str,
+        options: InviteOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Sends an invite to a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/send-invite
         """
@@ -393,7 +522,8 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("InviteOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.post(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.post(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -401,10 +531,18 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.send_invite_options LEAVE")
         return res
 
-    def send_invite(self, project_id: str, email: str, scope="member", timeout: httpx.Timeout = None):
+    def send_invite(
+        self,
+        project_id: str,
+        email: str,
+        scope="member",
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Sends an invite to a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/send-invite
         """
@@ -417,7 +555,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("options: %s", options)
-        result = self.post(url, json=options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.post(url, json=options, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -425,10 +564,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.send_invite LEAVE")
         return res
 
-    def delete_invite(self, project_id: str, email: str, timeout: httpx.Timeout = None):
+    def delete_invite(
+        self,
+        project_id: str,
+        email: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Deletes an invite from a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/delete-invite
         """
@@ -437,7 +583,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("email: %s", email)
-        result = self.delete(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.delete(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -445,10 +592,16 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.delete_invite LEAVE")
         return res
 
-    def leave_project(self, project_id: str, timeout: httpx.Timeout = None):
+    def leave_project(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Leaves a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/leave-project
         """
@@ -456,7 +609,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/leave"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.delete(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.delete(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Message.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -465,10 +619,17 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # usage
-    def get_usage_requests(self, project_id: str, options: UsageRequestOptions, timeout: httpx.Timeout = None):
+    def get_usage_requests(
+        self,
+        project_id: str,
+        options: UsageRequestOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of usage requests for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-all-requests
         """
@@ -480,7 +641,10 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("UsageRequestOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.get(url, options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(
+            url, options=options, timeout=timeout, addons=addons, **kwargs
+        )
         self.logger.info("json: %s", result)
         res = UsageRequestsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -488,10 +652,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_requests LEAVE")
         return res
 
-    def get_usage_request(self, project_id: str, request_id: str, timeout: httpx.Timeout = None):
+    def get_usage_request(
+        self,
+        project_id: str,
+        request_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets details for a specific usage request.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-request
         """
@@ -500,7 +671,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("request_id: %s", request_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = UsageRequest.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -508,10 +680,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_request LEAVE")
         return res
 
-    def get_usage_summary(self, project_id: str, options: UsageSummaryOptions, timeout: httpx.Timeout = None):
+    def get_usage_summary(
+        self,
+        project_id: str,
+        options: UsageSummaryOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a summary of usage for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/summarize-usage
         """
@@ -523,7 +702,10 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("UsageSummaryOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.get(url, options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(
+            url, options=options, timeout=timeout, addons=addons, **kwargs
+        )
         self.logger.info("json: %s", result)
         res = UsageSummaryResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -531,10 +713,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_usage_summary LEAVE")
         return res
 
-    def get_usage_fields(self, project_id: str, options: UsageFieldsOptions, timeout: httpx.Timeout = None):
+    def get_usage_fields(
+        self,
+        project_id: str,
+        options: UsageFieldsOptions,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of usage fields for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-fields
         """
@@ -546,7 +735,10 @@ class ManageClient(AbstractSyncRestClient):
             self.logger.info("UsageFieldsOptions switching class -> json")
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
-        result = self.get(url, options, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(
+            url, options=options, timeout=timeout, addons=addons, **kwargs
+        )
         self.logger.info("json: %s", result)
         res = UsageFieldsResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -555,16 +747,28 @@ class ManageClient(AbstractSyncRestClient):
         return res
 
     # balances
-    def list_balances(self, project_id: str, timeout: httpx.Timeout = None):
+    def list_balances(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Please see get_balances for more information.
         """
-        return self.get_balances(project_id)
+        return self.get_balances(project_id, timeout=timeout, addons=addons, **kwargs)
 
-    def get_balances(self, project_id: str, timeout: httpx.Timeout = None):
+    def get_balances(
+        self,
+        project_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets a list of balances for a project.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-all-balances
         """
@@ -572,7 +776,8 @@ class ManageClient(AbstractSyncRestClient):
         url = f"{self.config.url}/{self.endpoint}/{project_id}/balances"
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = BalancesResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -580,10 +785,17 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.debug("ManageClient.get_balances LEAVE")
         return res
 
-    def get_balance(self, project_id: str, balance_id: str, timeout: httpx.Timeout = None):
+    def get_balance(
+        self,
+        project_id: str,
+        balance_id: str,
+        timeout: httpx.Timeout = None,
+        addons: dict = None,
+        **kwargs,
+    ):
         """
         Gets details for a specific balance.
-        
+
         Reference:
         https://developers.deepgram.com/reference/get-balance
         """
@@ -592,7 +804,8 @@ class ManageClient(AbstractSyncRestClient):
         self.logger.info("url: %s", url)
         self.logger.info("project_id: %s", project_id)
         self.logger.info("balance_id: %s", balance_id)
-        result = self.get(url, timeout=timeout)
+        self.logger.info("addons: %s", addons)
+        result = self.get(url, timeout=timeout, addons=addons, **kwargs)
         self.logger.info("json: %s", result)
         res = Balance.from_json(result)
         self.logger.verbose("result: %s", res)

--- a/deepgram/clients/prerecorded/v1/async_client.py
+++ b/deepgram/clients/prerecorded/v1/async_client.py
@@ -46,6 +46,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         self,
         source: UrlSource,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url ENTER")
@@ -53,7 +54,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_url LEAVE")
             return await self.transcribe_url_callback(
-                source, options["callback"], options, endpoint
+                source, options["callback"], options, addons, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -66,11 +67,12 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
 
         self.logger.info("url: %s", url)
         self.logger.info("source: %s", source)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = await self.post(url, options=options, json=body)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, options=options, addons=addons, json=body)
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -99,6 +101,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         source: UrlSource,
         callback: str,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url_callback ENTER")
@@ -116,11 +119,12 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
 
         self.logger.info("url: %s", url)
         self.logger.info("source: %s", source)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = await self.post(url, options=options, json=body)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, options=options, addons=addons, json=body)
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -147,6 +151,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         self,
         source: FileSource,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file ENTER")
@@ -154,7 +159,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_file LEAVE")
             return await self.transcribe_file_callback(
-                source, options["callback"], options, endpoint
+                source, options["callback"], options, addons, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -168,11 +173,12 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             raise DeepgramTypeError("Unknown transcription source type")
 
         self.logger.info("url: %s", url)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = await self.post(url, options=options, content=body)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, options=options, addons=addons, content=body)
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -201,6 +207,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         source: FileSource,
         callback: str,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file_callback ENTER")
@@ -219,11 +226,12 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             raise DeepgramTypeError("Unknown transcription source type")
 
         self.logger.info("url: %s", url)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = await self.post(url, options=options, json=body)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = await self.post(url, options=options, addons=addons, json=body)
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)

--- a/deepgram/clients/prerecorded/v1/client.py
+++ b/deepgram/clients/prerecorded/v1/client.py
@@ -47,6 +47,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         self,
         source: UrlSource,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
@@ -55,7 +56,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_url LEAVE")
             return self.transcribe_url_callback(
-                source, options["callback"], options, endpoint
+                source, options["callback"], options, addons, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -68,11 +69,14 @@ class PreRecordedClient(AbstractSyncRestClient):
 
         self.logger.info("url: %s", url)
         self.logger.info("source: %s", source)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = self.post(url, options=options, json=body, timeout=timeout)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -101,6 +105,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         source: UrlSource,
         callback: str,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
@@ -119,11 +124,14 @@ class PreRecordedClient(AbstractSyncRestClient):
 
         self.logger.info("url: %s", url)
         self.logger.info("source: %s", source)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = self.post(url, options=options, json=body, timeout=timeout)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -150,6 +158,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         self,
         source: FileSource,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
@@ -158,7 +167,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_file LEAVE")
             return self.transcribe_file_callback(
-                source, options["callback"], options, endpoint
+                source, options["callback"], options, addons, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -172,11 +181,14 @@ class PreRecordedClient(AbstractSyncRestClient):
             raise DeepgramTypeError("Unknown transcription source type")
 
         self.logger.info("url: %s", url)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = self.post(url, options=options, content=body, timeout=timeout)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = self.post(
+            url, options=options, addons=addons, content=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -205,6 +217,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         source: FileSource,
         callback: str,
         options: PrerecordedOptions = None,
+        addons: dict = None,
         timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
@@ -224,11 +237,14 @@ class PreRecordedClient(AbstractSyncRestClient):
             raise DeepgramTypeError("Unknown transcription source type")
 
         self.logger.info("url: %s", url)
-        self.logger.info("options: %s", options)
         if isinstance(options, PrerecordedOptions):
             self.logger.info("PrerecordedOptions switching class -> json")
             options = json.loads(options.to_json())
-        result = self.post(url, options=options, json=body, timeout=timeout)
+        self.logger.info("options: %s", options)
+        self.logger.info("addons: %s", addons)
+        result = self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -5,6 +5,7 @@
 import os
 from dotenv import load_dotenv
 import logging, verboselogs
+from time import sleep
 
 from deepgram import (
     DeepgramClient,
@@ -19,10 +20,9 @@ load_dotenv()
 
 def main():
     try:
-        # example of setting up a client config
+        # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
         # config = DeepgramClientOptions(
-        #     verbose=logging.SPAM,
-        #     options={'keepalive': 'true'}
+        #     verbose=logging.SPAM, options={"keepalive": "true"}
         # )
         # deepgram: DeepgramClient = DeepgramClient("", config)
         # otherwise, use default config
@@ -30,13 +30,25 @@ def main():
 
         dg_connection = deepgram.listen.live.v("1")
 
-        def on_message(self, result, **kwargs):
+        def on_message(self, result, addon=dict(myattr=True), **kwargs):
             if result is None:
                 return
             sentence = result.channel.alternatives[0].transcript
             if len(sentence) == 0:
                 return
             print(f"speaker: {sentence}")
+
+            # testing modifying self class
+            if self.myattr is not None:
+                print(f"myattr - {self.myattr}")
+            else:
+                print("Setting myattr=hello")
+                setattr(self, "myattr", "hello")
+            self.myattr = "bye"
+
+            # testing kwargs
+            val = kwargs["test"]
+            print(f"kwargs - {val}")
 
         def on_metadata(self, metadata, **kwargs):
             if metadata is None:
@@ -59,7 +71,7 @@ def main():
             channels=1,
             sample_rate=16000,
         )
-        dg_connection.start(options)
+        dg_connection.start(options, addons=dict(myattr="hello"), test="hello")
 
         # Open a microphone stream
         microphone = Microphone(dg_connection.send)


### PR DESCRIPTION
This addresses issue: https://github.com/deepgram/deepgram-python-sdk/issues/212

This implements custom parameters for Live/Prerecorded/Manage Clients.

This implements:
- LiveClient can now accept custom attributes to be set for the `Class` as well as any arbitrate values (`**kwargs`) which will be passed into callback functions.
- ManageClient custom query parameters to be set in the URL as well as any arbitrate values (`**kwargs`) which will be passed any class that extends the ManageClient. This allows for custom params not related to Deepgram APIs.
- Updated `examples/streaming/microphone` to show how you can use these new capabilities in an application.

Verified that all examples work:
- `examples/manage`
- `examples/streaming`
- `examples/prerecorded`

Use this PR as the basis of updating https://github.com/deepgram/streaming-test-suite. You can find that implementation in this PR https://github.com/deepgram/streaming-test-suite/pull/11