### PR TITLE
WS Protocol Ping & Some Clean Up

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -162,6 +162,8 @@ class AsyncLiveClient:
             await self._socket.wait_closed()
             self.logger.notice("socket.wait_closed succeeded")
 
+        self._socket = None
+
         self.logger.notice("finish succeeded")
         self.logger.debug("AsyncLiveClient.finish LEAVE")
 

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -22,7 +22,8 @@ def main():
     try:
         # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
         # config = DeepgramClientOptions(
-        #     verbose=logging.SPAM, options={"keepalive": "true"}
+        #     verbose=logging.DEBUG,
+        #     options={"keepalive": "true"}
         # )
         # deepgram: DeepgramClient = DeepgramClient("", config)
         # otherwise, use default config
@@ -89,6 +90,8 @@ def main():
         dg_connection.finish()
 
         print("Finished")
+        # sleep(30)  # wait 30 seconds to see if there is any additional socket activity
+        # print("Really done!")
 
     except Exception as e:
         print(f"Could not open socket: {e}")


### PR DESCRIPTION
These shouldn't affect the operation of the live client... just more tidy-ing up.

Changes:
- Changing some logging message
- Always start the ping thread to allow WS protocol ping but optionally the Deepgram KeepAlive message
- decrease the amount of protocol level pings to the recommended 20ish seconds
- throwing exception for unknown message types which is over kill. just log the message type. this allows for new (future/unimplemented) messages from the Deepgram platform to be recognized and provide a warning instead.
- Clean-up like setting `_socket = Null` which shouldn't affect operation

Tested using `examples` and also the `test_suite.py`