### PR TITLE
Update README.md - Firm Min Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ You can learn more about the Deepgram API at [developers.deepgram.com](https://d
 
 [Python](https://www.python.org/downloads/) (version ^3.10)
 
-> **_NOTE:_** Althought many older versions should work.
-
 # Installation
 
 To install the latest version available (which will guarantee change over time):


### PR DESCRIPTION
Looks like 3.9 or lower won't work out of the box. Will need to explore if it's worth it. Until then...

3.10 has been around for a while (since 2020) and is in maintenance at this point.

3.8 will be EOL this year, 3.9 will be EOL next year. https://devguide.python.org/versions/

The min version (without going through heroic efforts) is a firm 3.10.