### PR TITLE
Fix Async Live Callback Definition

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -81,7 +81,7 @@ class AsyncLiveClient:
         self, event, *args, **kwargs
     ):  # triggers the registered event handlers for a specific event
         for handler in self._event_handlers[event]:
-            handler(self, *args, **kwargs)
+            await handler(self, *args, **kwargs)
 
     async def _start(self) -> None:
         self.logger.debug("AsyncLiveClient._start ENTER")

--- a/examples/streaming/async_http/main.py
+++ b/examples/streaming/async_http/main.py
@@ -28,7 +28,7 @@ async def main():
     try:
         dg_connection = deepgram.listen.asynclive.v("1")
 
-        def on_message(self, result, **kwargs):
+        async def on_message(self, result, **kwargs):
             if result is None:
                 return
             sentence = result.channel.alternatives[0].transcript
@@ -36,12 +36,12 @@ async def main():
                 return
             print(f"speaker: {sentence}")
 
-        def on_metadata(self, metadata, **kwargs):
+        async def on_metadata(self, metadata, **kwargs):
             if metadata is None:
                 return
             print(f"\n\n{metadata}\n\n")
 
-        def on_error(self, error, **kwargs):
+        async def on_error(self, error, **kwargs):
             if error is None:
                 return
             print(f"\n\n{error}\n\n")


### PR DESCRIPTION
This should address issue: https://github.com/deepgram/deepgram-python-sdk/issues/226

Callback functions for async live client should be `async/await`-able.

The `examples/streaming/async_http` has been updated to test this change.