### PR TITLE
Expose Response Classes for Inheritance

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -9,32 +9,37 @@ __version__ = "0.0.0"
 from .client import Deepgram, DeepgramClient
 from .options import DeepgramClientOptions
 
-# live
-from .clients import LiveTranscriptionEvents
-from .clients import LiveClient, AsyncLiveClient, LiveOptions
+# listen client
+from .client import ListenClient
 
-# onprem
-from .clients import (
-    OnPremClient,
-    AsyncOnPremClient,
+# live
+from .client import LiveTranscriptionEvents
+from .client import LiveClient, AsyncLiveClient
+from .client import LiveOptions
+from .client import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
 )
 
 # prerecorded
-from .clients import (
-    PreRecordedClient,
-    AsyncPreRecordedClient,
-    PrerecordedOptions,
+from .client import PreRecordedClient, AsyncPreRecordedClient
+from .client import (
     PrerecordedSource,
     FileSource,
     UrlSource,
     BufferSource,
     ReadStreamSource,
+    PrerecordedOptions,
+)
+from .client import (
+    AsyncPrerecordedResponse,
+    PrerecordedResponse,
 )
 
 # manage
-from .clients import (
-    ManageClient,
-    AsyncManageClient,
+from .client import ManageClient, AsyncManageClient
+from .client import (
     ProjectOptions,
     KeyOptions,
     ScopeOptions,
@@ -42,6 +47,31 @@ from .clients import (
     UsageRequestOptions,
     UsageSummaryOptions,
     UsageFieldsOptions,
+)
+
+# manage client responses
+from .client import (
+    Message,
+    Project,
+    ProjectsResponse,
+    MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
+    ScopesResponse,
+    InvitesResponse,
+    UsageRequest,
+    UsageRequestsResponse,
+    UsageSummaryResponse,
+    UsageFieldsResponse,
+    Balance,
+    BalancesResponse,
+)
+
+# onprem
+from .client import (
+    OnPremClient,
+    AsyncOnPremClient,
 )
 
 # utilities

--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -7,19 +7,74 @@ from importlib import import_module
 import logging, verboselogs
 import os
 
-from .clients.listen import (
-    ListenClient,
-    PreRecordedClient,
-    AsyncLiveClient,
-    AsyncPreRecordedClient,
-    PrerecordedOptions,
+# listen client
+from .clients import ListenClient
+
+# live
+from .clients import LiveClient, AsyncLiveClient
+from .clients import (
     LiveOptions,
     LiveTranscriptionEvents,
 )
+
+# live client responses
+from .clients import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)
+
+# prerecorded
+from .clients import PreRecordedClient, AsyncPreRecordedClient
+from .clients import (
+    PrerecordedSource,
+    FileSource,
+    UrlSource,
+    BufferSource,
+    ReadStreamSource,
+    PrerecordedOptions,
+)
+
+# prerecorded client responses
+from .clients import (
+    AsyncPrerecordedResponse,
+    PrerecordedResponse,
+)
+
+# manage client classes/input
+from .clients import ManageClient, AsyncManageClient
+from .clients import (
+    ProjectOptions,
+    KeyOptions,
+    ScopeOptions,
+    InviteOptions,
+    UsageRequestOptions,
+    UsageSummaryOptions,
+    UsageFieldsOptions,
+)
+
+# manage client responses
+from .clients import (
+    Message,
+    Project,
+    ProjectsResponse,
+    MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
+    ScopesResponse,
+    InvitesResponse,
+    UsageRequest,
+    UsageRequestsResponse,
+    UsageSummaryResponse,
+    UsageFieldsResponse,
+    Balance,
+    BalancesResponse,
+)
+
+# on-prem
 from .clients.onprem.client import OnPremClient
 from .clients.onprem.v1.async_client import AsyncOnPremClient
-from .clients.manage.client import ManageClient
-from .clients.manage.v1.async_client import AsyncManageClient
 
 from .options import DeepgramClientOptions
 from .errors import DeepgramApiKeyError, DeepgramModuleError

--- a/deepgram/clients/__init__.py
+++ b/deepgram/clients/__init__.py
@@ -2,16 +2,21 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+# listen
+from .listen import ListenClient
+
 # live
-from .live import LiveClient
-from .live import AsyncLiveClient
+from .live import LiveClient, AsyncLiveClient
 from .live import LiveOptions
 from .live import LiveTranscriptionEvents
-from ..options import DeepgramClientOptions
+from .live import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)
 
 # prerecorded
-from .prerecorded import PreRecordedClient
-from .prerecorded import AsyncPreRecordedClient
+from .prerecorded import PreRecordedClient, AsyncPreRecordedClient
 from .prerecorded import PrerecordedOptions
 from .prerecorded import (
     PrerecordedSource,
@@ -20,16 +25,13 @@ from .prerecorded import (
     BufferSource,
     ReadStreamSource,
 )
-from ..options import DeepgramClientOptions
-
-# onprem
-from .onprem import OnPremClient
-from .onprem import AsyncOnPremClient
-from ..options import DeepgramClientOptions
+from .prerecorded import (
+    AsyncPrerecordedResponse,
+    PrerecordedResponse,
+)
 
 # manage
-from .manage import ManageClient
-from .manage import AsyncManageClient
+from .manage import ManageClient, AsyncManageClient
 from .manage import (
     ProjectOptions,
     KeyOptions,
@@ -39,4 +41,26 @@ from .manage import (
     UsageSummaryOptions,
     UsageFieldsOptions,
 )
+from .manage import (
+    Message,
+    Project,
+    ProjectsResponse,
+    MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
+    ScopesResponse,
+    InvitesResponse,
+    UsageRequest,
+    UsageRequestsResponse,
+    UsageSummaryResponse,
+    UsageFieldsResponse,
+    Balance,
+    BalancesResponse,
+)
+
+# onprem
+from .onprem import OnPremClient, AsyncOnPremClient
+
+# client options
 from ..options import DeepgramClientOptions

--- a/deepgram/clients/listen.py
+++ b/deepgram/clients/listen.py
@@ -6,22 +6,37 @@ from importlib import import_module
 import logging, verboselogs
 
 from ..options import DeepgramClientOptions
+from .errors import DeepgramModuleError
 
+# live client
+# classes and input
 from .prerecorded.client import (
     PreRecordedClient,
     AsyncPreRecordedClient,
     PrerecordedOptions,
 )
+
+# responses
+from .prerecorded.client import (
+    AsyncPrerecordedResponse,
+    PrerecordedResponse,
+)
+
+# live client
+# classes and input
 from .live.client import (
     LiveClient,
     AsyncLiveClient,
     LiveOptions,
+    LiveTranscriptionEvents,
+)
+
+# responses
+from .live.client import (
     LiveResultResponse,
     MetadataResponse,
     ErrorResponse,
-    LiveTranscriptionEvents,
 )
-from .errors import DeepgramModuleError
 
 
 class ListenClient:
@@ -44,6 +59,7 @@ class ListenClient:
         asynclive: Returns an (Async) LiveClient instance for interacting with Deepgram's transcription services.
         asyncprerecorded: Returns an (Async) PreRecordedClient instance for interacting with Deepgram's prerecorded transcription services.
     """
+
     def __init__(self, config: DeepgramClientOptions):
         self.logger = logging.getLogger(__name__)
         self.logger.addHandler(logging.StreamHandler())

--- a/deepgram/clients/live/__init__.py
+++ b/deepgram/clients/live/__init__.py
@@ -2,8 +2,13 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from .v1.client import LiveClient
-from .v1.async_client import AsyncLiveClient
+from .client import LiveClient
+from .client import AsyncLiveClient
 from .v1.options import LiveOptions
 from .enums import LiveTranscriptionEvents
 from ...options import DeepgramClientOptions
+from .client import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)

--- a/deepgram/clients/live/client.py
+++ b/deepgram/clients/live/client.py
@@ -6,29 +6,66 @@ from .v1.client import LiveClient as LiveClientLatest
 from .v1.async_client import AsyncLiveClient as AsyncLiveClientLatest
 from .v1.options import LiveOptions as LiveOptionsLatest
 from .enums import LiveTranscriptionEvents
-from .v1.response import LiveResultResponse, MetadataResponse, ErrorResponse
+from .v1.response import (
+    LiveResultResponse as LiveResultResponseLatest,
+    MetadataResponse as MetadataResponseLatest,
+    ErrorResponse as ErrorResponseLatest,
+)
 
 """
 The vX/client.py points to the current supported version in the SDK.
 Older versions are supported in the SDK for backwards compatibility.
 """
 
+
+# input
 class LiveOptions(LiveOptionsLatest):
     """
     pass through for LiveOptions based on API version
     """
+
     pass
 
+
+# responses
+class LiveResultResponse(LiveResultResponseLatest):
+    """
+    pass through for LiveResultResponse based on API version
+    """
+
+    pass
+
+
+class MetadataResponse(MetadataResponseLatest):
+    """
+    pass through for MetadataResponse based on API version
+    """
+
+    pass
+
+
+class ErrorResponse(ErrorResponseLatest):
+    """
+    pass through for ErrorResponse based on API version
+    """
+
+    pass
+
+
+# clients
 class LiveClient(LiveClientLatest):
     """
     Please see LiveClientLatest for details
     """
+
     def __init__(self, config):
         super().__init__(config)
+
 
 class AsyncLiveClient(AsyncLiveClientLatest):
     """
     Please see LiveClientLatest for details
     """
+
     def __init__(self, config):
         super().__init__(config)

--- a/deepgram/clients/live/enums.py
+++ b/deepgram/clients/live/enums.py
@@ -7,10 +7,12 @@ from enum import Enum
 """
 Constants mapping to events from the Deepgram API
 """
+
+
 class LiveTranscriptionEvents(Enum):
-    Open = "open"
-    Close = "close"
+    Open = "Open"
+    Close = "Close"
     Transcript = "Results"
     Metadata = "Metadata"
-    Error = "error"
-    Warning = "warning"
+    Error = "Error"
+    Warning = "Warning"

--- a/deepgram/clients/live/v1/__init__.py
+++ b/deepgram/clients/live/v1/__init__.py
@@ -6,3 +6,8 @@ from .client import LiveClient
 from .async_client import AsyncLiveClient
 from .options import LiveOptions
 from ....options import DeepgramClientOptions
+from .response import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)

--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -11,7 +11,11 @@ from ..enums import LiveTranscriptionEvents
 from ..helpers import convert_to_websocket_url, append_query_params
 from ..errors import DeepgramError
 
-from .response import LiveResultResponse, MetadataResponse, ErrorResponse
+from .response import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)
 from .options import LiveOptions
 
 
@@ -96,6 +100,9 @@ class AsyncLiveClient:
                             "response_type: %s, data: %s", response_type, data
                         )
                         result = LiveResultResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("LiveResultResponse.from_json is None")
+                            continue
                         await self._emit(
                             LiveTranscriptionEvents.Transcript,
                             result=result,
@@ -105,7 +112,10 @@ class AsyncLiveClient:
                         self.logger.debug(
                             "response_type: %s, data: %s", response_type, data
                         )
-                        result = ErrorResponse.from_json(message)
+                        result = MetadataResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("MetadataResponse.from_json is None")
+                            continue
                         await self._emit(
                             LiveTranscriptionEvents.Metadata,
                             metadata=result,
@@ -115,7 +125,10 @@ class AsyncLiveClient:
                         self.logger.debug(
                             "response_type: %s, data: %s", response_type, data
                         )
-                        result = MetadataResponse.from_json(message)
+                        result = ErrorResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("ErrorResponse.from_json is None")
+                            continue
                         await self._emit(
                             LiveTranscriptionEvents.Error,
                             error=result,

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -12,7 +12,11 @@ from ..enums import LiveTranscriptionEvents
 from ..helpers import convert_to_websocket_url, append_query_params
 from ..errors import DeepgramError, DeepgramWebsocketError
 
-from .response import LiveResultResponse, MetadataResponse, ErrorResponse
+from .response import (
+    LiveResultResponse,
+    MetadataResponse,
+    ErrorResponse,
+)
 from .options import LiveOptions
 
 PING_INTERVAL = 5
@@ -127,6 +131,9 @@ class LiveClient:
                             "response_type: %s, data: %s", response_type, data
                         )
                         result = LiveResultResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("LiveResultResponse.from_json is None")
+                            continue
                         self._emit(
                             LiveTranscriptionEvents.Transcript,
                             result=result,
@@ -137,6 +144,9 @@ class LiveClient:
                             "response_type: %s, data: %s", response_type, data
                         )
                         result = MetadataResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("MetadataResponse.from_json is None")
+                            continue
                         self._emit(
                             LiveTranscriptionEvents.Metadata,
                             metadata=result,
@@ -147,6 +157,9 @@ class LiveClient:
                             "response_type: %s, data: %s", response_type, data
                         )
                         result = ErrorResponse.from_json(message)
+                        if result is None:
+                            self.logger.error("ErrorResponse.from_json is None")
+                            continue
                         self._emit(
                             LiveTranscriptionEvents.Error,
                             error=result,

--- a/deepgram/clients/live/v1/options.py
+++ b/deepgram/clients/live/v1/options.py
@@ -12,10 +12,11 @@ from typing import List, Optional
 class LiveOptions:
     """
     Live Transcription Options for the Deepgram Platform.
-    
+
     Please see the documentation for more information on each option:
     https://developers.deepgram.com/reference/streaming
     """
+
     callback: Optional[str] = None
     channels: Optional[int] = None
     diarize: Optional[bool] = None
@@ -36,6 +37,7 @@ class LiveOptions:
     smart_format: Optional[bool] = None
     tag: Optional[list] = None
     tier: Optional[str] = None
+    utterance_end_ms: Optional[str] = None
     version: Optional[str] = None
 
     def __getitem__(self, key):

--- a/deepgram/clients/live/v1/response.py
+++ b/deepgram/clients/live/v1/response.py
@@ -9,6 +9,7 @@ from typing import List, Optional, Dict
 
 # Result Message
 
+
 @dataclass_json
 @dataclass
 class Word:
@@ -85,6 +86,7 @@ class LiveResultResponse:
     """
     Result Message from the Deepgram Platform
     """
+
     type: Optional[str] = ""
     channel_index: Optional[List[int]] = None
     duration: Optional[float] = 0
@@ -109,6 +111,7 @@ class LiveResultResponse:
 
 # Metadata Message
 
+
 @dataclass_json
 @dataclass
 class ModelInfo:
@@ -127,6 +130,7 @@ class MetadataResponse:
     """
     Metadata Message from the Deepgram Platform
     """
+
     type: Optional[str] = ""
     transaction_key: Optional[str] = ""
     request_id: Optional[str] = ""
@@ -146,8 +150,10 @@ class MetadataResponse:
                 ModelInfo.from_dict(value) for value in _dict["model_info"]
             ]
         return _dict[key]
-    
+
+
 # Error Message
+
 
 @dataclass_json
 @dataclass
@@ -155,6 +161,7 @@ class ErrorResponse:
     """
     Error Message from the Deepgram Platform
     """
+
     description: Optional[str] = ""
     message: Optional[str] = ""
     type: Optional[str] = ""

--- a/deepgram/clients/manage/__init__.py
+++ b/deepgram/clients/manage/__init__.py
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from .v1.client import ManageClient
-from .v1.async_client import AsyncManageClient
-from .v1.options import (
+from .client import ManageClient
+from .client import AsyncManageClient
+from .client import (
     ProjectOptions,
     KeyOptions,
     ScopeOptions,
@@ -12,5 +12,22 @@ from .v1.options import (
     UsageRequestOptions,
     UsageSummaryOptions,
     UsageFieldsOptions,
+)
+from .client import (
+    Message,
+    Project,
+    ProjectsResponse,
+    MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
+    ScopesResponse,
+    InvitesResponse,
+    UsageRequest,
+    UsageRequestsResponse,
+    UsageSummaryResponse,
+    UsageFieldsResponse,
+    Balance,
+    BalancesResponse,
 )
 from ...options import DeepgramClientOptions

--- a/deepgram/clients/manage/client.py
+++ b/deepgram/clients/manage/client.py
@@ -4,6 +4,8 @@
 
 from .v1.client import ManageClient as ManageClientLatest
 from .v1.async_client import AsyncManageClient as AsyncManageClientLatest
+
+# input
 from .v1.options import (
     ProjectOptions as ProjectOptionsLatest,
     KeyOptions as KeyOptionsLatest,
@@ -14,16 +16,38 @@ from .v1.options import (
     UsageFieldsOptions as UsageFieldsOptionsLatest,
 )
 
+# responses
+from .v1.response import (
+    Message as MessageLatest,
+    Project as ProjectLatest,
+    ProjectsResponse as ProjectsResponseLatest,
+    MembersResponse as MembersResponseLatest,
+    Key as KeyLatest,
+    KeyResponse as KeyResponseLatest,
+    KeysResponse as KeysResponseLatest,
+    ScopesResponse as ScopesResponseLatest,
+    InvitesResponse as InvitesResponseLatest,
+    UsageRequest as UsageRequestLatest,
+    UsageRequestsResponse as UsageRequestsResponseLatest,
+    UsageSummaryResponse as UsageSummaryResponseLatest,
+    UsageFieldsResponse as UsageFieldsResponseLatest,
+    Balance as BalanceLatest,
+    BalancesResponse as BalancesResponseLatest,
+)
+
+
 """
 The client.py points to the current supported version in the SDK.
 Older versions are supported in the SDK for backwards compatibility.
 """
 
 
+# input
 class ProjectOptions(ProjectOptionsLatest):
     """
     pass through for ProjectOptions based on API version
     """
+
     pass
 
 
@@ -31,6 +55,7 @@ class KeyOptions(KeyOptionsLatest):
     """
     pass through for KeyOptions based on API version
     """
+
     pass
 
 
@@ -38,6 +63,7 @@ class ScopeOptions(ScopeOptionsLatest):
     """
     pass through for ScopeOptions based on API version
     """
+
     pass
 
 
@@ -45,6 +71,7 @@ class InviteOptions(InviteOptionsLatest):
     """
     pass through for InviteOptions based on API version
     """
+
     pass
 
 
@@ -52,6 +79,7 @@ class UsageRequestOptions(UsageRequestOptionsLatest):
     """
     pass through for UsageRequestOptions based on API version
     """
+
     pass
 
 
@@ -59,6 +87,7 @@ class UsageSummaryOptions(UsageSummaryOptionsLatest):
     """
     pass through for UsageSummaryOptions based on API version
     """
+
     pass
 
 
@@ -66,13 +95,137 @@ class UsageFieldsOptions(UsageFieldsOptionsLatest):
     """
     pass through for UsageFieldsOptions based on API version
     """
+
     pass
 
 
+# responses
+class Message(MessageLatest):
+    """
+    pass through for Message based on API version
+    """
+
+    pass
+
+
+class Project(ProjectLatest):
+    """
+    pass through for Project based on API version
+    """
+
+    pass
+
+
+class ProjectsResponse(ProjectsResponseLatest):
+    """
+    pass through for ProjectsResponse based on API version
+    """
+
+    pass
+
+
+class MembersResponse(MembersResponseLatest):
+    """
+    pass through for MembersResponse based on API version
+    """
+
+    pass
+
+
+class Key(KeyLatest):
+    """
+    pass through for Key based on API version
+    """
+
+    pass
+
+
+class KeyResponse(KeyResponseLatest):
+    """
+    pass through for KeyResponse based on API version
+    """
+
+    pass
+
+
+class KeysResponse(KeysResponseLatest):
+    """
+    pass through for KeysResponse based on API version
+    """
+
+    pass
+
+
+class ScopesResponse(ScopesResponseLatest):
+    """
+    pass through for ScopesResponse based on API version
+    """
+
+    pass
+
+
+class InvitesResponse(InvitesResponseLatest):
+    """
+    pass through for InvitesResponse based on API version
+    """
+
+    pass
+
+
+class UsageRequest(UsageRequestLatest):
+    """
+    pass through for UsageRequest based on API version
+    """
+
+    pass
+
+
+class UsageRequestsResponse(UsageRequestsResponseLatest):
+    """
+    pass through for UsageRequestsResponse based on API version
+    """
+
+    pass
+
+
+class UsageSummaryResponse(UsageSummaryResponseLatest):
+    """
+    pass through for UsageSummaryResponse based on API version
+    """
+
+    pass
+
+
+class UsageFieldsResponse(UsageFieldsResponseLatest):
+    """
+    pass through for UsageFieldsResponse based on API version
+    """
+
+    pass
+
+
+class Balance(BalanceLatest):
+    """
+    pass through for Balance based on API version
+    """
+
+    pass
+
+
+class BalancesResponse(BalancesResponseLatest):
+    """
+    pass through for BalancesResponse based on API version
+    """
+
+    pass
+
+
+# clients
 class ManageClient(ManageClientLatest):
     """
     Please see ManageClientLatest for details
     """
+
     def __init__(self, config):
         super().__init__(config)
 
@@ -81,5 +234,6 @@ class AsyncManageClient(AsyncManageClientLatest):
     """
     Please see AsyncManageClientLatest for details
     """
+
     def __init__(self, config):
         super().__init__(config)

--- a/deepgram/clients/manage/v1/__init__.py
+++ b/deepgram/clients/manage/v1/__init__.py
@@ -13,4 +13,21 @@ from .options import (
     UsageSummaryOptions,
     UsageFieldsOptions,
 )
+from .response import (
+    Message,
+    Project,
+    ProjectsResponse,
+    MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
+    ScopesResponse,
+    InvitesResponse,
+    UsageRequest,
+    UsageRequestsResponse,
+    UsageSummaryResponse,
+    UsageFieldsResponse,
+    Balance,
+    BalancesResponse,
+)
 from ....options import DeepgramClientOptions

--- a/deepgram/clients/manage/v1/async_client.py
+++ b/deepgram/clients/manage/v1/async_client.py
@@ -8,21 +8,21 @@ from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 
 from .response import (
+    Message,
     Project,
     ProjectsResponse,
-    Message,
-    KeysResponse,
-    KeyResponse,
-    Key,
     MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
     ScopesResponse,
     InvitesResponse,
-    UsageRequestsResponse,
     UsageRequest,
+    UsageRequestsResponse,
     UsageSummaryResponse,
     UsageFieldsResponse,
-    BalancesResponse,
     Balance,
+    BalancesResponse,
 )
 from .options import (
     ProjectOptions,
@@ -59,13 +59,13 @@ class AsyncManageClient(AbstractAsyncRestClient):
         super().__init__(config)
 
     # projects
-    async def list_projects(self, addons: dict = None, **kwargs):
+    async def list_projects(self, addons: dict = None, **kwargs) -> ProjectsResponse:
         """
         Please see get_projects for more information.
         """
         return self.get_projects(addons=addons, **kwargs)
 
-    async def get_projects(self, addons: dict = None, **kwargs):
+    async def get_projects(self, addons: dict = None, **kwargs) -> ProjectsResponse:
         """
         Gets a list of projects for the authenticated user.
 
@@ -84,7 +84,9 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.debug("ManageClient.get_projects LEAVE")
         return res
 
-    async def get_project(self, project_id: str, addons: dict = None, **kwargs):
+    async def get_project(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> Project:
         """
         Gets details for a specific project.
 
@@ -106,7 +108,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def update_project_option(
         self, project_id: str, options: ProjectOptions, addons: dict = None, **kwargs
-    ):
+    ) -> Message:
         """
         Updates a project's settings.
 
@@ -129,7 +131,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def update_project(
         self, project_id: str, name="", addons: dict = None, **kwargs
-    ):
+    ) -> Message:
         """
         Updates a project's settings.
 
@@ -155,7 +157,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def delete_project(
         self, project_id: str, addons: dict = None, **kwargs
-    ) -> None:
+    ) -> Message:
         """
         Deletes a project.
 
@@ -174,13 +176,17 @@ class AsyncManageClient(AbstractAsyncRestClient):
         return res
 
     # keys
-    async def list_keys(self, project_id: str, addons: dict = None, **kwargs):
+    async def list_keys(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> KeysResponse:
         """
         Please see get_keys for more information.
         """
         return self.get_keys(project_id, addons=addons, **kwargs)
 
-    async def get_keys(self, project_id: str, addons: dict = None, **kwargs):
+    async def get_keys(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> KeysResponse:
         """
         Gets a list of keys for a project.
 
@@ -202,7 +208,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def get_key(
         self, project_id: str, key_id: str, addons: dict = None, **kwargs
-    ):
+    ) -> KeyResponse:
         """
         Gets details for a specific key.
 
@@ -225,7 +231,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def create_key(
         self, project_id: str, options: KeyOptions, addons: dict = None, **kwargs
-    ):
+    ) -> Key:
         """
         Creates a new key.
 
@@ -248,7 +254,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def delete_key(
         self, project_id: str, key_id: str, addons: dict = None, **kwargs
-    ) -> None:
+    ) -> Message:
         """
         Deletes a key.
 
@@ -270,13 +276,17 @@ class AsyncManageClient(AbstractAsyncRestClient):
         return res
 
     # members
-    async def list_members(self, project_id: str, addons: dict = None, **kwargs):
+    async def list_members(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> MembersResponse:
         """
         Please see get_members for more information.
         """
         return self.get_members(project_id, addons=addons, **kwargs)
 
-    async def get_members(self, project_id: str, addons: dict = None, **kwargs):
+    async def get_members(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> MembersResponse:
         """
         Gets a list of members for a project.
 
@@ -298,7 +308,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def remove_member(
         self, project_id: str, member_id: str, addons: dict = None, **kwargs
-    ) -> None:
+    ) -> Message:
         """
         Removes a member from a project.
 
@@ -322,7 +332,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
     # scopes
     async def get_member_scopes(
         self, project_id: str, member_id: str, addons: dict = None, **kwargs
-    ):
+    ) -> ScopesResponse:
         """
         Gets a list of scopes for a member.
 
@@ -352,7 +362,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
         options: ScopeOptions,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Updates a member's scopes.
 
@@ -376,13 +386,17 @@ class AsyncManageClient(AbstractAsyncRestClient):
         return res
 
     # invites
-    async def list_invites(self, project_id: str, addons: dict = None, **kwargs):
+    async def list_invites(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> InvitesResponse:
         """
         Please see get_invites for more information.
         """
         return self.get_invites(project_id, addons=addons, **kwargs)
 
-    async def get_invites(self, project_id: str, addons: dict = None, **kwargs):
+    async def get_invites(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> InvitesResponse:
         """
         Gets a list of invites for a project.
 
@@ -404,7 +418,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def send_invite_options(
         self, project_id: str, options: InviteOptions, addons: dict = None, **kwargs
-    ):
+    ) -> Message:
         """
         Sends an invite to a project.
 
@@ -427,7 +441,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def send_invite(
         self, project_id: str, email: str, scope="member", addons: dict = None, **kwargs
-    ):
+    ) -> Message:
         """
         Sends an invite to a project.
 
@@ -454,7 +468,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def delete_invite(
         self, project_id: str, email: str, addons: dict = None, **kwargs
-    ):
+    ) -> Message:
         """
         Deletes an invite from a project.
 
@@ -475,7 +489,9 @@ class AsyncManageClient(AbstractAsyncRestClient):
         self.logger.debug("ManageClient.delete_invite LEAVE")
         return res
 
-    async def leave_project(self, project_id: str, addons: dict = None, **kwargs):
+    async def leave_project(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> Message:
         """
         Leaves a project.
 
@@ -502,7 +518,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
         options: UsageRequestOptions,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageRequestsResponse:
         """
         Gets a list of usage requests for a project.
 
@@ -525,7 +541,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def get_usage_request(
         self, project_id: str, request_id: str, addons: dict = None, **kwargs
-    ):
+    ) -> UsageRequest:
         """
         Gets details for a specific usage request.
 
@@ -552,7 +568,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
         options: UsageSummaryOptions,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageSummaryResponse:
         """
         Gets a summary of usage for a project.
 
@@ -579,7 +595,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
         options: UsageFieldsOptions,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageFieldsResponse:
         """
         Gets a list of usage fields for a project.
 
@@ -601,13 +617,17 @@ class AsyncManageClient(AbstractAsyncRestClient):
         return res
 
     # balances
-    async def list_balances(self, project_id: str, addons: dict = None, **kwargs):
+    async def list_balances(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> BalancesResponse:
         """
         Please see get_balances for more information.
         """
         return self.get_balances(project_id, addons=addons, **kwargs)
 
-    async def get_balances(self, project_id: str, addons: dict = None, **kwargs):
+    async def get_balances(
+        self, project_id: str, addons: dict = None, **kwargs
+    ) -> BalancesResponse:
         """
         Gets a list of balances for a project.
 
@@ -629,7 +649,7 @@ class AsyncManageClient(AbstractAsyncRestClient):
 
     async def get_balance(
         self, project_id: str, balance_id: str, addons: dict = None, **kwargs
-    ):
+    ) -> Balance:
         """
         Gets details for a specific balance.
 

--- a/deepgram/clients/manage/v1/client.py
+++ b/deepgram/clients/manage/v1/client.py
@@ -10,21 +10,21 @@ from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 
 from .response import (
+    Message,
     Project,
     ProjectsResponse,
-    Message,
-    KeysResponse,
-    KeyResponse,
-    Key,
     MembersResponse,
+    Key,
+    KeyResponse,
+    KeysResponse,
     ScopesResponse,
     InvitesResponse,
-    UsageRequestsResponse,
     UsageRequest,
+    UsageRequestsResponse,
     UsageSummaryResponse,
     UsageFieldsResponse,
-    BalancesResponse,
     Balance,
+    BalancesResponse,
 )
 from .options import (
     ProjectOptions,
@@ -64,7 +64,7 @@ class ManageClient(AbstractSyncRestClient):
     # projects
     def list_projects(
         self, timeout: httpx.Timeout = None, addons: dict = None, **kwargs
-    ):
+    ) -> ProjectsResponse:
         """
         List all projects for the current user.
         """
@@ -72,7 +72,7 @@ class ManageClient(AbstractSyncRestClient):
 
     def get_projects(
         self, timeout: httpx.Timeout = None, addons: dict = None, **kwargs
-    ):
+    ) -> ProjectsResponse:
         """
         Gets a list of projects for the authenticated user.
 
@@ -97,7 +97,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Project:
         """
         Gets details for a specific project.
 
@@ -124,7 +124,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Updates a project's settings.
 
@@ -155,7 +155,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Updates a project's settings.
 
@@ -185,7 +185,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ) -> None:
+    ) -> Message:
         """
         Deletes a project.
 
@@ -210,7 +210,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> KeysResponse:
         """
         Please see get_keys for more information.
         """
@@ -222,7 +222,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> KeysResponse:
         """
         Gets a list of keys for a project.
 
@@ -249,7 +249,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> KeyResponse:
         """
         Gets details for a specific key.
 
@@ -277,7 +277,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Key:
         """
         Creates a new key.
 
@@ -308,7 +308,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ) -> None:
+    ) -> Message:
         """
         Deletes a key.
 
@@ -336,7 +336,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> MembersResponse:
         """
         Please see get_members for more information.
         """
@@ -348,7 +348,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> MembersResponse:
         """
         Gets a list of members for a project.
 
@@ -375,7 +375,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ) -> None:
+    ) -> Message:
         """
         Removes a member from a project.
 
@@ -404,7 +404,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> ScopesResponse:
         """
         Gets a list of scopes for a member.
 
@@ -435,7 +435,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Updates a member's scopes.
 
@@ -468,7 +468,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> InvitesResponse:
         """
         Please see get_invites for more information.
         """
@@ -480,7 +480,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> InvitesResponse:
         """
         Gets a list of invites for a project.
 
@@ -507,7 +507,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Sends an invite to a project.
 
@@ -539,7 +539,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Sends an invite to a project.
 
@@ -571,7 +571,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Deletes an invite from a project.
 
@@ -598,7 +598,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Message:
         """
         Leaves a project.
 
@@ -626,7 +626,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageRequestsResponse:
         """
         Gets a list of usage requests for a project.
 
@@ -659,7 +659,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageRequest:
         """
         Gets details for a specific usage request.
 
@@ -687,7 +687,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageSummaryResponse:
         """
         Gets a summary of usage for a project.
 
@@ -720,7 +720,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> UsageFieldsResponse:
         """
         Gets a list of usage fields for a project.
 
@@ -753,7 +753,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> BalancesResponse:
         """
         Please see get_balances for more information.
         """
@@ -765,7 +765,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> BalancesResponse:
         """
         Gets a list of balances for a project.
 
@@ -792,7 +792,7 @@ class ManageClient(AbstractSyncRestClient):
         timeout: httpx.Timeout = None,
         addons: dict = None,
         **kwargs,
-    ):
+    ) -> Balance:
         """
         Gets details for a specific balance.
 

--- a/deepgram/clients/manage/v1/response.py
+++ b/deepgram/clients/manage/v1/response.py
@@ -7,6 +7,7 @@ from dataclasses_json import dataclass_json
 from datetime import datetime
 from typing import TypedDict, List, Optional
 
+
 # Result Message
 
 
@@ -77,6 +78,8 @@ class MembersResponse:
 
 
 # Keys
+
+
 @dataclass_json
 @dataclass
 class Key:
@@ -122,6 +125,8 @@ class KeysResponse:
 
 
 # Scopes
+
+
 @dataclass_json
 @dataclass
 class ScopesResponse:
@@ -161,6 +166,8 @@ class InvitesResponse:
 
 
 # Usage
+
+
 @dataclass_json
 @dataclass
 class Config:

--- a/deepgram/clients/prerecorded/__init__.py
+++ b/deepgram/clients/prerecorded/__init__.py
@@ -2,9 +2,9 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from .v1.client import PreRecordedClient
-from .v1.async_client import AsyncPreRecordedClient
-from .v1.options import PrerecordedOptions
+from .client import PreRecordedClient
+from .client import AsyncPreRecordedClient
+from .client import PrerecordedOptions
 from .source import (
     PrerecordedSource,
     FileSource,
@@ -12,5 +12,6 @@ from .source import (
     BufferSource,
     ReadStreamSource,
 )
+from .client import AsyncPrerecordedResponse, PrerecordedResponse
 
 from ...options import DeepgramClientOptions

--- a/deepgram/clients/prerecorded/client.py
+++ b/deepgram/clients/prerecorded/client.py
@@ -6,6 +6,10 @@ from .v1.client import PreRecordedClient as PreRecordedClientLatest
 from .v1.async_client import AsyncPreRecordedClient as AsyncPreRecordedClientLatest
 from .v1.options import PrerecordedOptions as PrerecordedOptionsLatest
 from .source import PrerecordedSource, FileSource, UrlSource
+from .v1.response import (
+    AsyncPrerecordedResponse as AsyncPrerecordedResponseLatest,
+    PrerecordedResponse as PrerecordedResponseLatest,
+)
 
 """
 The client.py points to the current supported version in the SDK.
@@ -13,17 +17,38 @@ Older versions are supported in the SDK for backwards compatibility.
 """
 
 
+# input
 class PrerecordedOptions(PrerecordedOptionsLatest):
     """
     Please see PrerecordedOptionsLatest for details
     """
+
     pass
 
 
+# output
+class AsyncPrerecordedResponse(AsyncPrerecordedResponseLatest):
+    """
+    Please see AsyncPrerecordedResponseLatest for details
+    """
+
+    pass
+
+
+class PrerecordedResponse(PrerecordedResponseLatest):
+    """
+    Please see PrerecordedResponseLatest for details
+    """
+
+    pass
+
+
+# clients
 class PreRecordedClient(PreRecordedClientLatest):
     """
     Please see PreRecordedClientLatest for details
     """
+
     def __init__(self, config):
         self.config = config
         super().__init__(config)
@@ -33,5 +58,6 @@ class AsyncPreRecordedClient(AsyncPreRecordedClientLatest):
     """
     Please see AsyncPreRecordedClientLatest for details
     """
+
     def __init__(self, config):
         super().__init__(config)

--- a/deepgram/clients/prerecorded/v1/__init__.py
+++ b/deepgram/clients/prerecorded/v1/__init__.py
@@ -6,3 +6,4 @@ from .client import PreRecordedClient
 from .async_client import AsyncPreRecordedClient
 from .options import PrerecordedOptions
 from ....options import DeepgramClientOptions
+from .response import AsyncPrerecordedResponse, PrerecordedResponse

--- a/examples/streaming/http/main.py
+++ b/examples/streaming/http/main.py
@@ -3,11 +3,16 @@
 # SPDX-License-Identifier: MIT
 
 import httpx
-import os
 from dotenv import load_dotenv
+import logging, verboselogs
 import threading
 
-from deepgram import DeepgramClient, LiveTranscriptionEvents, LiveOptions
+from deepgram import (
+    DeepgramClient,
+    DeepgramClientOptions,
+    LiveTranscriptionEvents,
+    LiveOptions,
+)
 
 load_dotenv()
 
@@ -17,6 +22,12 @@ URL = "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service"
 
 def main():
     try:
+        # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
+        # config = DeepgramClientOptions(
+        #     verbose=logging.DEBUG, options={"keepalive": "true"}
+        # )
+        # deepgram: DeepgramClient = DeepgramClient("", config)
+        # otherwise, use default config
         deepgram = DeepgramClient()
 
         # Create a websocket connection to Deepgram

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -2,7 +2,6 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-import os
 from dotenv import load_dotenv
 import logging, verboselogs
 from time import sleep


### PR DESCRIPTION
This should allow an end user to fully extend the Prerecorded, Live, and Manage Clients by allowing both: 1) the ability to declare these as return types and 2) the ability to marshal and unmarshal these object types in the inherited class.

Tested all examples to make sure nothing was affected.