### PR TITLE
Improved Exception Message for REST Calls

### DIFF
--- a/deepgram/clients/abstract_async_client.py
+++ b/deepgram/clients/abstract_async_client.py
@@ -101,7 +101,7 @@ class AbstractAsyncRestClient:
                 try:
                     json_object = json.loads(e.response.text)
                     raise DeepgramApiError(
-                        json_object.get("message"), status_code, json.dumps(json_object)
+                        json_object.get("err_msg"), status_code, json.dumps(json_object)
                     ) from e
                 except json.decoder.JSONDecodeError:
                     raise DeepgramUnknownApiError(e.response.text, status_code) from e

--- a/deepgram/clients/abstract_sync_client.py
+++ b/deepgram/clients/abstract_sync_client.py
@@ -110,7 +110,7 @@ class AbstractSyncRestClient:
                 try:
                     json_object = json.loads(e.response.text)
                     raise DeepgramApiError(
-                        json_object.get("message"), status_code, json.dumps(json_object)
+                        json_object.get("err_msg"), status_code, json.dumps(json_object)
                     ) from e
                 except json.decoder.JSONDecodeError:
                     raise DeepgramUnknownApiError(e.response.text, status_code) from e


### PR DESCRIPTION
This addresses issue https://github.com/deepgram/deepgram-python-sdk/issues/240 filed by @jonahweissman in the community. This should improve exception error messages for REST API calls.