### PR TITLE
Missing Speaker Index on Live Stream

### DIFF
--- a/deepgram/clients/live/v1/response.py
+++ b/deepgram/clients/live/v1/response.py
@@ -18,6 +18,7 @@ class Word:
     end: Optional[float] = 0
     confidence: Optional[float] = 0
     punctuated_word: Optional[str] = ""
+    speaker: Optional[int] = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()


### PR DESCRIPTION
Just like the title says... Missing Speaker Index on Live Stream. Similar issue on Go SDK:
https://github.com/deepgram/deepgram-go-sdk/pull/152