### PR TITLE
Implement Timeout for Async REST API Call

### DIFF
--- a/deepgram/clients/abstract_sync_client.py
+++ b/deepgram/clients/abstract_sync_client.py
@@ -31,7 +31,6 @@ class AbstractSyncRestClient:
     def __init__(self, config: DeepgramClientOptions):
         if config is None:
             raise DeepgramError("Config are required")
-
         self.config = config
 
     def get(self, url: str, options=None, addons=None, timeout=None, **kwargs):
@@ -97,7 +96,7 @@ class AbstractSyncRestClient:
             new_url = append_query_params(new_url, addons)
 
         if timeout is None:
-            timeout = httpx.Timeout(10.0, connect=10.0)
+            timeout = httpx.Timeout(30.0, connect=10.0)
 
         try:
             with httpx.Client(timeout=timeout) as client:

--- a/deepgram/clients/prerecorded/v1/async_client.py
+++ b/deepgram/clients/prerecorded/v1/async_client.py
@@ -2,6 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
+import httpx
+import logging, verboselogs
 import json
 import logging, verboselogs
 
@@ -47,6 +49,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         source: UrlSource,
         options: PrerecordedOptions = None,
         addons: dict = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url ENTER")
@@ -54,7 +57,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_url LEAVE")
             return await self.transcribe_url_callback(
-                source, options["callback"], options, addons, endpoint
+                source, options["callback"], options, addons, timeout, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -72,7 +75,9 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
         self.logger.info("addons: %s", addons)
-        result = await self.post(url, options=options, addons=addons, json=body)
+        result = await self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -102,6 +107,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         callback: str,
         options: PrerecordedOptions = None,
         addons: dict = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_url_callback ENTER")
@@ -124,7 +130,9 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
         self.logger.info("addons: %s", addons)
-        result = await self.post(url, options=options, addons=addons, json=body)
+        result = await self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -152,6 +160,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         source: FileSource,
         options: PrerecordedOptions = None,
         addons: dict = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> PrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file ENTER")
@@ -159,7 +168,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_file LEAVE")
             return await self.transcribe_file_callback(
-                source, options["callback"], options, addons, endpoint
+                source, options["callback"], options, addons, timeout, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -178,7 +187,9 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
         self.logger.info("addons: %s", addons)
-        result = await self.post(url, options=options, addons=addons, content=body)
+        result = await self.post(
+            url, options=options, addons=addons, content=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = PrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)
@@ -208,6 +219,7 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
         callback: str,
         options: PrerecordedOptions = None,
         addons: dict = None,
+        timeout: httpx.Timeout = None,
         endpoint: str = "v1/listen",
     ) -> AsyncPrerecordedResponse:
         self.logger.debug("PreRecordedClient.transcribe_file_callback ENTER")
@@ -231,7 +243,9 @@ class AsyncPreRecordedClient(AbstractAsyncRestClient):
             options = json.loads(options.to_json())
         self.logger.info("options: %s", options)
         self.logger.info("addons: %s", addons)
-        result = await self.post(url, options=options, addons=addons, json=body)
+        result = await self.post(
+            url, options=options, addons=addons, json=body, timeout=timeout
+        )
         self.logger.info("json: %s", result)
         res = AsyncPrerecordedResponse.from_json(result)
         self.logger.verbose("result: %s", res)

--- a/deepgram/clients/prerecorded/v1/client.py
+++ b/deepgram/clients/prerecorded/v1/client.py
@@ -56,7 +56,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_url LEAVE")
             return self.transcribe_url_callback(
-                source, options["callback"], options, addons, endpoint
+                source, options["callback"], options, addons, timeout, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"
@@ -167,7 +167,7 @@ class PreRecordedClient(AbstractSyncRestClient):
         if options is not None and options.callback is not None:
             self.logger.debug("PreRecordedClient.transcribe_file LEAVE")
             return self.transcribe_file_callback(
-                source, options["callback"], options, addons, endpoint
+                source, options["callback"], options, addons, timeout, endpoint
             )
 
         url = f"{self.config.url}/{endpoint}"

--- a/examples/prerecorded/file/main.py
+++ b/examples/prerecorded/file/main.py
@@ -5,6 +5,7 @@
 import os
 from dotenv import load_dotenv
 import logging, verboselogs
+from datetime import datetime, timedelta
 
 from deepgram import (
     DeepgramClientOptions,
@@ -42,8 +43,15 @@ def main():
             punctuate=True,
             diarize=True,
         )
+
+        before = datetime.now()
         response = deepgram.listen.prerecorded.v("1").transcribe_file(payload, options)
+        after = datetime.now()
+
         print(response.to_json(indent=4))
+        print("")
+        difference = after - before
+        print(f"time: {difference.seconds}")
 
     except Exception as e:
         print(f"Exception: {e}")


### PR DESCRIPTION
I had implemented a timeout for Threaded/Sync REST calls, but forgot to implement timeout for Async.

Tested using:
`examples/prerecorded/async_url`
and works great!

Addresses issue: https://github.com/deepgram/deepgram-python-sdk/issues/248