### PR TITLE
fix:issue of exception on websocket closing

### DIFF
--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: MIT
 import json
 from websockets.sync.client import connect
+import websockets
 import threading
 import time
 import logging, verboselogs
@@ -191,7 +192,7 @@ class LiveClient:
                             data,
                         )
 
-            except Exception as e:
+            except websockets.exceptions.ConnectionClosedOK as e:
                 if e.code == 1000:
                     self.logger.notice("_listening(1000) exiting gracefully")
                     self.logger.debug("LiveClient._listening LEAVE")

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -197,7 +197,19 @@ class LiveClient:
                     self.logger.notice("_listening(1000) exiting gracefully")
                     self.logger.debug("LiveClient._listening LEAVE")
                     return
+                else:
+                    error: ErrorResponse = {
+                    "type": "Exception",
+                    "description": "Unknown error _listening",
+                    "message": f"{e}",
+                    "variant": "",
+                }
+                    self.logger.error(f"WebSocket connection closed with code {e.code}: {e.reason}")
+                    self._emit(LiveTranscriptionEvents.Error, error)
+                    self.logger.debug("LiveClient._listening LEAVE")
+                    raise
 
+            except Exception as e:
                 error: ErrorResponse = {
                     "type": "Exception",
                     "description": "Unknown error _listening",
@@ -205,9 +217,9 @@ class LiveClient:
                     "variant": "",
                 }
                 self._emit(LiveTranscriptionEvents.Error, error)
-
                 self.logger.error("Exception in _listening: %s", str(e))
                 self.logger.debug("LiveClient._listening LEAVE")
+                raise
 
     def _processing(self) -> None:
         self.logger.debug("LiveClient._processing ENTER")


### PR DESCRIPTION
I found that the general `Exception` being thrown in [line 194](https://github.com/deepgram/deepgram-python-sdk/blob/main/deepgram/clients/live/v1/client.py#L194C30-L194C30) gave confusing info. 

I did some research and found that it's not common to raise an exception for a normal closure of a WebSocket connection with a close code of 1000. A close code of 1000 indicates a normal closure, where the connection is being closed gracefully. Raising an exception for a normal closure might be confusing and goes against the typical use of exceptions to signal errors or exceptional conditions. In the code as it was before, the exception handling seems to be used more for control flow (to exit the listening thread) rather than to handle an error.

So I opted to use `ConnectionClosedOK` which is a specific exception class for handling a normal closure with a close code of 1000. This means the exception will be handled for just this specific acceptable outcome, and the user will see the notice message but not see an error.