### PR TITLE
Port SyncClient Exception Handling to Async Client

### DIFF
--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -199,12 +199,14 @@ class LiveClient:
                     return
                 else:
                     error: ErrorResponse = {
-                    "type": "Exception",
-                    "description": "Unknown error _listening",
-                    "message": f"{e}",
-                    "variant": "",
-                }
-                    self.logger.error(f"WebSocket connection closed with code {e.code}: {e.reason}")
+                        "type": "Exception",
+                        "description": "Unknown error _listening",
+                        "message": f"{e}",
+                        "variant": "",
+                    }
+                    self.logger.error(
+                        f"WebSocket connection closed with code {e.code}: {e.reason}"
+                    )
                     self._emit(LiveTranscriptionEvents.Error, error)
                     self.logger.debug("LiveClient._listening LEAVE")
                     raise


### PR DESCRIPTION
This ports the change in the Thread/Sync client to the AsyncClient:
https://github.com/deepgram/deepgram-python-sdk/pull/256

Also fixes a small formatting issue in the SyncClient.