### PR TITLE
Remove Beta From URL in Read Examples

### DIFF
--- a/examples/analyze/intent/main.py
+++ b/examples/analyze/intent/main.py
@@ -22,11 +22,12 @@ TEXT_FILE = "conversation.txt"
 def main():
     try:
         # STEP 1 Create a Deepgram client using the API key in the environment variables
-        config = DeepgramClientOptions(
-            # verbose=logging.SPAM,
-            url="api.beta.deepgram.com",
-        )
-        deepgram = DeepgramClient("", config)
+        # config = DeepgramClientOptions(
+        #     verbose=logging.SPAM,
+        # )
+        # deepgram = DeepgramClient("", config)
+        # OR use defaults
+        deepgram = DeepgramClient()
 
         # STEP 2 Call the transcribe_file method on the prerecorded class
         with open(TEXT_FILE, "r") as file:

--- a/examples/analyze/sentiment/main.py
+++ b/examples/analyze/sentiment/main.py
@@ -22,11 +22,12 @@ TEXT_FILE = "conversation.txt"
 def main():
     try:
         # STEP 1 Create a Deepgram client using the API key in the environment variables
-        config = DeepgramClientOptions(
-            # verbose=logging.SPAM,
-            url="api.beta.deepgram.com",
-        )
-        deepgram = DeepgramClient("", config)
+        # config = DeepgramClientOptions(
+        #     verbose=logging.SPAM,
+        # )
+        # deepgram = DeepgramClient("", config)
+        # OR use defaults
+        deepgram = DeepgramClient()
 
         # STEP 2 Call the transcribe_file method on the prerecorded class
         with open(TEXT_FILE, "r") as file:

--- a/examples/analyze/summary/main.py
+++ b/examples/analyze/summary/main.py
@@ -22,11 +22,12 @@ TEXT_FILE = "conversation.txt"
 def main():
     try:
         # STEP 1 Create a Deepgram client using the API key in the environment variables
-        config = DeepgramClientOptions(
-            # verbose=logging.SPAM,
-            url="api.beta.deepgram.com",
-        )
-        deepgram = DeepgramClient("", config)
+        # config = DeepgramClientOptions(
+        #     verbose=logging.SPAM,
+        # )
+        # deepgram = DeepgramClient("", config)
+        # OR use defaults
+        deepgram = DeepgramClient()
 
         # STEP 2 Call the transcribe_file method on the prerecorded class
         with open(TEXT_FILE, "r") as file:

--- a/examples/analyze/topic/main.py
+++ b/examples/analyze/topic/main.py
@@ -22,11 +22,12 @@ TEXT_FILE = "conversation.txt"
 def main():
     try:
         # STEP 1 Create a Deepgram client using the API key in the environment variables
-        config = DeepgramClientOptions(
-            # verbose=logging.SPAM,
-            url="api.beta.deepgram.com",
-        )
-        deepgram = DeepgramClient("", config)
+        # config = DeepgramClientOptions(
+        #     verbose=logging.SPAM,
+        # )
+        # deepgram = DeepgramClient("", config)
+        # OR use defaults
+        deepgram = DeepgramClient()
 
         # STEP 2 Call the transcribe_file method on the prerecorded class
         with open(TEXT_FILE, "r") as file:


### PR DESCRIPTION
`/read` is now in production. Change URL in examples from `api.beta.deepgram.com` to the standard URL.

Tested the examples and they return the proper results.