### PR TITLE
removes unnecessary warning

### DIFF
--- a/deepgram/clients/live/v1/options.py
+++ b/deepgram/clients/live/v1/options.py
@@ -57,10 +57,6 @@ class LiveOptions:
         prev = logger.level
         logger.setLevel(logging.ERROR)
 
-        if self.numerals:
-            logger.error(
-                "WARNING: Numerals is deprecated. Will be removed in a future version. Please use smart_format instead."
-            )
         if self.tier:
             logger.error(
                 "WARNING: Tier is deprecated. Will be removed in a future version."

--- a/deepgram/clients/prerecorded/v1/options.py
+++ b/deepgram/clients/prerecorded/v1/options.py
@@ -67,10 +67,6 @@ class PrerecordedOptions:
         prev = logger.level
         logger.setLevel(logging.ERROR)
 
-        if self.numerals:
-            logger.error(
-                "WARNING: Numerals is deprecated. Will be removed in a future version. Please use smart_format instead."
-            )
         if self.tier:
             logger.error(
                 "WARNING: Tier is deprecated. Will be removed in a future version."


### PR DESCRIPTION
## Proposed changes

The warning that numerals will be deprecated isn't accurate (I believe). It was the feature `numbers` that was deprecated, but `numerals` will not be deprecated.


## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

