### PR TITLE
Fix Explicitly Passing API Key to `DeepgramClient`

### DIFF
--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -158,12 +158,13 @@ class DeepgramClient:
         self.logger = logging.getLogger(__name__)
         self.logger.addHandler(logging.StreamHandler())
 
-        if config is not None:
+        if api_key == "" and config is not None:
+            self.logger.info("Attempting to set API key from config object")
             api_key = config.api_key
-        if not api_key:
-            # Default to `None` for on-prem instances where an API key is not required
-            api_key = os.getenv("DEEPGRAM_API_KEY", None)
-        if not api_key:
+        if api_key == "":
+            self.logger.info("Attempting to set API key from environment variable")
+            api_key = os.getenv("DEEPGRAM_API_KEY", "")
+        if api_key == "":
             self.logger.warning("WARNING: API key is missing")
 
         self.api_key = api_key


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses issue: https://github.com/deepgram/deepgram-python-sdk/issues/283

Fix Explicitly Passing API Key to `DeepgramClient`. The bug was due to switching the "empty" API key from "", to None, empty. We will always just deal with the API key in terms of "".

Tested without environment variables and also made sure that the the environment variable method is unaffected.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

NA