### PR TITLE
Fix _emit not being awaited

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -225,7 +225,7 @@ class AsyncLiveClient:
                     self.logger.error(
                         f"WebSocket connection closed with code {e.code}: {e.reason}"
                     )
-                    self._emit(LiveTranscriptionEvents.Error, error=error)
+                    await self._emit(LiveTranscriptionEvents.Error, error=error)
                     self.logger.debug("AsyncLiveClient._start LEAVE")
                     raise
             except Exception as e:
@@ -235,7 +235,7 @@ class AsyncLiveClient:
                     "message": f"{e}",
                     "variant": "",
                 }
-                self._emit(LiveTranscriptionEvents.Error, error)
+                await self._emit(LiveTranscriptionEvents.Error, error)
                 self.logger.error("Exception in _start: %s", error=error)
                 self.logger.debug("AsyncLiveClient._start LEAVE")
                 raise


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
`_emit` is not being awaited, which leads to `RuntimeWarning: coroutine 'AsyncLiveClient._emit' was never awaited
  self._emit(LiveTranscriptionEvents.Error, error)`

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

