### PR TITLE
Bugfix: manage resources properly

### DIFF
--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -313,9 +313,8 @@ class LiveClient:
         self.logger.spam("data: %s", data)
 
         if self._socket:
-            self.lock_send.acquire()
-            ret = self._socket.send(data)
-            self.lock_send.release()
+            with self.lock_send:
+                ret = self._socket.send(data)
 
             self.logger.spam(f"send bytes: {ret}")
             self.logger.spam("LiveClient.send LEAVE")

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -331,9 +331,8 @@ class LiveClient:
         self.logger.spam("LiveClient.send_ping ENTER")
 
         if self._socket:
-            self.lock_send.acquire()
-            self._socket.ping()
-            self.lock_send.release()
+            with self.lock_send:
+                self._socket.ping()
 
         self.logger.spam("LiveClient.send_ping LEAVE")
 


### PR DESCRIPTION
## Proposed changes

Manage multi-threaded resources with Python's built-in syntax, to avoid deadlocks.


## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

minimal reproducible example:

```python
import time

from deepgram import DeepgramClient, LiveOptions

deepgram_client = DeepgramClient(api_key=API_KEY)
deepgram_connection = deepgram_client.listen.live.v("1")

deepgram_connection.start(LiveOptions())

time.sleep(30)    # Deepgram will close the connection after 10-15s of silence, followed with another 5 seconds for a ping

print('deadlock!')
try:
  deepgram_connection.finish()
finally:
  print('no deadlock...')
```

output:
```
Exception in _listening: received 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001; then sent 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001
Exception in thread Thread-5 (_listening):
Traceback (most recent call last):
  File "/Users/tom/my/lib/mambaforge/envs/dev3/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/Users/tom/my/lib/mambaforge/envs/dev3/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/tom/my/lib/mambaforge/envs/dev3/lib/python3.10/site-packages/deepgram/clients/live/v1/client.py", line 146, in _listening
    message = self._socket.recv()
  File "/Users/tom/my/lib/mambaforge/envs/dev3/lib/python3.10/site-packages/websockets/sync/connection.py", line 201, in recv
    raise self.protocol.close_exc from self.recv_events_exc
websockets.exceptions.ConnectionClosedError: received 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001; then sent 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001
Exception in _processing: received 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001; then sent 1011 (internal error) Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001
deadlock!
```