### PR TITLE
Fix Exception Handling When Platform Sends Close (From Timeout)

### DIFF
--- a/examples/streaming/http/main.py
+++ b/examples/streaming/http/main.py
@@ -23,9 +23,7 @@ URL = "http://stream.live.vc.bbcmedia.co.uk/bbc_world_service"
 def main():
     try:
         # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
-        # config = DeepgramClientOptions(
-        #     verbose=logging.DEBUG, options={"keepalive": "true"}
-        # )
+        # config = DeepgramClientOptions(verbose=logging.DEBUG)
         # deepgram: DeepgramClient = DeepgramClient("", config)
         # otherwise, use default config
         deepgram = DeepgramClient()

--- a/tests/exception/main.py
+++ b/tests/exception/main.py
@@ -1,0 +1,21 @@
+import time
+import logging, verboselogs
+
+from deepgram import DeepgramClient, DeepgramClientOptions, LiveOptions
+
+config = DeepgramClientOptions(verbose=logging.DEBUG)
+deepgram = DeepgramClient("", config)
+
+deepgram_connection = deepgram.listen.live.v("1")
+
+deepgram_connection.start(LiveOptions())
+
+time.sleep(
+    30
+)  # Deepgram will close the connection after 10-15s of silence, followed with another 5 seconds for a ping
+
+print("deadlock!")
+try:
+    deepgram_connection.finish()
+finally:
+    print("no deadlock...")


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This should address issue https://github.com/deepgram/deepgram-python-sdk/pull/305

Changes include:
- Moves `self._socket` check in `__init__` up right as not to overwrite setting values
- Clean exit and consolidate using `def signal_exit(self):`

Tested with `examples/streaming` and also while receiving a timeout.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA
