### PR TITLE
Examine JSON DataClasses and Remove `Optional` for Those That are Required

### DIFF
--- a/deepgram/clients/analyze/v1/options.py
+++ b/deepgram/clients/analyze/v1/options.py
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 
 from io import BufferedReader
 from typing import Union, Optional
@@ -20,17 +20,39 @@ class AnalyzeOptions:
     https://developers.deepgram.com/reference/text-intelligence-apis
     """
 
-    callback: Optional[str] = None
-    callback_method: Optional[str] = None
-    custom_intent: Optional[Union[list, str]] = None
-    custom_intent_mode: Optional[str] = None
-    custom_topic: Optional[Union[list, str]] = None
-    custom_topic_mode: Optional[str] = None
-    intents: Optional[bool] = None
-    language: Optional[str] = None
-    sentiment: Optional[bool] = None
-    summarize: Optional[bool] = None
-    topics: Optional[bool] = None
+    callback: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    callback_method: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_intent: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_intent_mode: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_topic: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_topic_mode: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    intents: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    language: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    sentiment: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    summarize: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    topics: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -69,7 +91,7 @@ class StreamSource:
         stream (BufferedReader): A BufferedReader object for reading binary data.
     """
 
-    stream: BufferedReader
+    stream: BufferedReader = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -95,7 +117,7 @@ class UrlSource:
         url (str): The URL pointing to the hosted file.
     """
 
-    url: str
+    url: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -121,7 +143,7 @@ class BufferSource:
         buffer (bytes): The binary data.
     """
 
-    buffer: bytes
+    buffer: bytes = b""
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/analyze/v1/response.py
+++ b/deepgram/clients/analyze/v1/response.py
@@ -14,7 +14,7 @@ from ..enums import Sentiment
 @dataclass_json
 @dataclass
 class AsyncAnalyzeResponse:
-    request_id: Optional[str] = ""
+    request_id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -30,9 +30,9 @@ class AsyncAnalyzeResponse:
 @dataclass_json
 @dataclass
 class IntentsInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -45,9 +45,9 @@ class IntentsInfo:
 @dataclass_json
 @dataclass
 class SentimentInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -60,9 +60,9 @@ class SentimentInfo:
 @dataclass_json
 @dataclass
 class SummaryInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -75,9 +75,9 @@ class SummaryInfo:
 @dataclass_json
 @dataclass
 class TopicsInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -90,9 +90,9 @@ class TopicsInfo:
 @dataclass_json
 @dataclass
 class Metadata:
-    request_id: Optional[str] = ""
-    created: Optional[str] = ""
-    language: Optional[str] = ""
+    request_id: str = ""
+    created: str = ""
+    language: str = ""
     intents_info: Optional[IntentsInfo] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -125,10 +125,8 @@ class Metadata:
 @dataclass_json
 @dataclass
 class Average:
-    sentiment: Optional[Sentiment] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    sentiment_score: Optional[float] = 0
+    sentiment: Sentiment = None
+    sentiment_score: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -143,7 +141,7 @@ class Average:
 @dataclass_json
 @dataclass
 class Summary:
-    text: Optional[str] = ""
+    text: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -156,8 +154,8 @@ class Summary:
 @dataclass_json
 @dataclass
 class Topic:
-    topic: Optional[str] = ""
-    confidence_score: Optional[float] = 0
+    topic: str = ""
+    confidence_score: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -170,8 +168,8 @@ class Topic:
 @dataclass_json
 @dataclass
 class Intent:
-    intent: Optional[str] = ""
-    confidence_score: Optional[float] = 0
+    intent: str = ""
+    confidence_score: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -184,9 +182,9 @@ class Intent:
 @dataclass_json
 @dataclass
 class Segment:
-    text: Optional[str] = ""
-    start_word: Optional[int] = 0
-    end_word: Optional[int] = 0
+    text: str = ""
+    start_word: int = 0
+    end_word: int = 0
     sentiment: Optional[Sentiment] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -215,12 +213,8 @@ class Segment:
 @dataclass_json
 @dataclass
 class Sentiments:
-    segments: Optional[List[Segment]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    average: Optional[Average] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    segments: List[Segment] = None
+    average: Average = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -239,9 +233,7 @@ class Sentiments:
 @dataclass_json
 @dataclass
 class Topics:
-    segments: Optional[List[Segment]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    segments: List[Segment] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -258,9 +250,7 @@ class Topics:
 @dataclass_json
 @dataclass
 class Intents:
-    segments: Optional[List[Segment]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    segments: List[Segment] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/live/v1/options.py
+++ b/deepgram/clients/live/v1/options.py
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 from typing import List, Optional, Union
 import logging, verboselogs
 
@@ -18,34 +18,90 @@ class LiveOptions:
     https://developers.deepgram.com/reference/streaming
     """
 
-    alternatives: Optional[int] = None
-    callback: Optional[str] = None
-    callback_method: Optional[str] = None
-    channels: Optional[int] = None
-    diarize: Optional[bool] = None
-    diarize_version: Optional[str] = None
-    encoding: Optional[str] = None
-    endpointing: Optional[str] = None
-    extra: Optional[Union[list, str]] = None
-    filler_words: Optional[bool] = None
-    interim_results: Optional[bool] = None
-    keywords: Optional[str] = None
-    language: Optional[str] = None
-    model: Optional[str] = None
-    multichannel: Optional[bool] = None
-    numerals: Optional[bool] = None
-    punctuate: Optional[bool] = None
-    profanity_filter: Optional[bool] = None
-    redact: Optional[bool] = None
-    replace: Optional[str] = None
-    sample_rate: Optional[int] = None
-    search: Optional[str] = None
-    smart_format: Optional[bool] = None
-    tag: Optional[list] = None
-    tier: Optional[str] = None
-    utterance_end_ms: Optional[str] = None
-    vad_events: Optional[bool] = None
-    version: Optional[str] = None
+    alternatives: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    callback: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    callback_method: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    channels: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    diarize: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    diarize_version: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    encoding: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    endpointing: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    extra: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    filler_words: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    interim_results: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    keywords: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    language: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    model: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    multichannel: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    numerals: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    punctuate: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    profanity_filter: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    redact: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    replace: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    sample_rate: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    search: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    smart_format: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    tag: Optional[list] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    tier: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    utterance_end_ms: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    vad_events: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    version: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/live/v1/response.py
+++ b/deepgram/clients/live/v1/response.py
@@ -13,11 +13,13 @@ from typing import List, Optional, Dict
 @dataclass_json
 @dataclass
 class Word:
-    word: Optional[str] = ""
-    start: Optional[float] = 0
-    end: Optional[float] = 0
-    confidence: Optional[float] = 0
-    punctuated_word: Optional[str] = ""
+    word: str = ""
+    start: float = 0
+    end: float = 0
+    confidence: float = 0
+    punctuated_word: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
     speaker: Optional[int] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -36,11 +38,9 @@ class Word:
 @dataclass_json
 @dataclass
 class Alternative:
-    transcript: Optional[str] = ""
-    confidence: Optional[float] = 0
-    words: Optional[List[Word]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    transcript: str = ""
+    confidence: float = 0
+    words: List[Word] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -58,9 +58,7 @@ class Alternative:
 @dataclass_json
 @dataclass
 class Channel:
-    alternatives: Optional[List[Alternative]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    alternatives: List[Alternative] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -81,9 +79,9 @@ class Channel:
 @dataclass_json
 @dataclass
 class ModelInfo:
-    name: Optional[str] = ""
-    version: Optional[str] = ""
-    arch: Optional[str] = ""
+    name: str = ""
+    version: str = ""
+    arch: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -99,11 +97,11 @@ class ModelInfo:
 @dataclass_json
 @dataclass
 class Metadata:
-    request_id: Optional[str] = ""
-    model_info: Optional[ModelInfo] = field(
+    request_id: str = ""
+    model_info: ModelInfo = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
-    model_uuid: Optional[str] = ""
+    model_uuid: str = ""
     extra: Optional[Dict[str, str]] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -132,18 +130,14 @@ class LiveResultResponse:
     Result Message from the Deepgram Platform
     """
 
-    type: Optional[str] = ""
-    channel_index: Optional[List[int]] = None
-    duration: Optional[float] = 0
-    start: Optional[float] = 0
-    is_final: Optional[bool] = False
-    speech_final: Optional[bool] = False
-    channel: Optional[Channel] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    metadata: Optional[Metadata] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    type: str = ""
+    channel_index: List[int] = None
+    duration: float = 0
+    start: float = 0
+    is_final: bool = False
+    speech_final: bool = False
+    channel: Channel = None
+    metadata: Metadata = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -170,9 +164,9 @@ class LiveResultResponse:
 @dataclass_json
 @dataclass
 class ModelInfo:
-    name: Optional[str] = ""
-    version: Optional[str] = ""
-    arch: Optional[str] = ""
+    name: str = ""
+    version: str = ""
+    arch: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -192,19 +186,15 @@ class MetadataResponse:
     Metadata Message from the Deepgram Platform
     """
 
-    type: Optional[str] = ""
-    transaction_key: Optional[str] = ""
-    request_id: Optional[str] = ""
-    sha256: Optional[str] = ""
-    created: Optional[str] = ""
-    duration: Optional[float] = 0
-    channels: Optional[int] = 0
-    models: Optional[List[str]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    model_info: Optional[Dict[str, ModelInfo]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    type: str = ""
+    transaction_key: str = ""
+    request_id: str = ""
+    sha256: str = ""
+    created: str = ""
+    duration: float = 0
+    channels: int = 0
+    models: List[str] = None
+    model_info: Dict[str, ModelInfo] = None
     extra: Optional[Dict] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -239,9 +229,9 @@ class SpeechStartedResponse:
     SpeechStartedResponse Message from the Deepgram Platform
     """
 
-    type: Optional[str] = ""
-    channel: Optional[List[int]] = None
-    timestamp: Optional[float] = 0
+    type: str = ""
+    channel: List[int] = None
+    timestamp: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -264,9 +254,9 @@ class UtteranceEndResponse:
     UtteranceEnd Message from the Deepgram Platform
     """
 
-    type: Optional[str] = ""
-    channel: Optional[List[int]] = None
-    last_word_end: Optional[float] = 0
+    type: str = ""
+    channel: List[int] = None
+    last_word_end: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -289,9 +279,9 @@ class ErrorResponse:
     Error Message from the Deepgram Platform
     """
 
-    description: Optional[str] = ""
-    message: Optional[str] = ""
-    type: Optional[str] = ""
+    description: str = ""
+    message: str = ""
+    type: str = ""
     variant: Optional[str] = ""
 
     def __getitem__(self, key):

--- a/deepgram/clients/manage/v1/options.py
+++ b/deepgram/clients/manage/v1/options.py
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 from datetime import datetime
 from typing import TypedDict, List, Optional
 
@@ -13,7 +13,7 @@ from typing import TypedDict, List, Optional
 @dataclass_json
 @dataclass
 class ProjectOptions:
-    name: Optional[str] = ""
+    name: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -30,10 +30,16 @@ class ProjectOptions:
 @dataclass
 class KeyOptions:
     comment: Optional[str] = ""
-    time_to_live_in_seconds: Optional[int] = 0
-    expiration_date: Optional[str] = ""
-    scopes: Optional[List[str]] = None
-    tags: Optional[List[str]] = None
+    time_to_live_in_seconds: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    expiration_date: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    scopes: List[str] = None
+    tags: Optional[List[str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -53,7 +59,7 @@ class KeyOptions:
 @dataclass_json
 @dataclass
 class ScopeOptions:
-    scope: Optional[str] = ""
+    scope: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -69,8 +75,8 @@ class ScopeOptions:
 @dataclass_json
 @dataclass
 class InviteOptions:
-    email: Optional[str] = ""
-    scope: Optional[str] = ""
+    email: str = ""
+    scope: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -86,10 +92,18 @@ class InviteOptions:
 @dataclass_json
 @dataclass
 class UsageRequestOptions:
-    start: Optional[str] = ""
-    end: Optional[str] = ""
-    limit: Optional[int] = 0
-    status: Optional[str] = ""
+    start: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    end: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    limit: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    status: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -105,27 +119,69 @@ class UsageRequestOptions:
 @dataclass_json
 @dataclass
 class UsageSummaryOptions:
-    start: Optional[str] = ""
-    end: Optional[str] = ""
-    accessor: Optional[str] = ""
-    tag: Optional[str] = ""
-    method: Optional[str] = ""
-    model: Optional[str] = ""
-    multichannel: Optional[bool] = False
-    interim_results: Optional[bool] = False
-    punctuate: Optional[bool] = False
-    ner: Optional[bool] = False
-    utterances: Optional[bool] = False
-    replace: Optional[bool] = False
-    profanity_filter: Optional[bool] = False
-    keywords: Optional[bool] = False
-    detect_topics: Optional[bool] = False
-    diarize: Optional[bool] = False
-    search: Optional[bool] = False
-    redact: Optional[bool] = False
-    alternatives: Optional[bool] = False
-    numerals: Optional[bool] = False
-    smart_format: Optional[bool] = False
+    start: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    end: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    accessor: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    tag: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    method: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    model: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    multichannel: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    interim_results: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    punctuate: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    ner: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    utterances: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    replace: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    profanity_filter: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    keywords: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    detect_topics: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    diarize: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    search: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    redact: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    alternatives: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    numerals: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    smart_format: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/manage/v1/response.py
+++ b/deepgram/clients/manage/v1/response.py
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 from datetime import datetime
 from typing import TypedDict, List, Optional
 
@@ -14,7 +14,7 @@ from typing import TypedDict, List, Optional
 @dataclass_json
 @dataclass
 class Message:
-    message: Optional[str] = ""
+    message: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -33,8 +33,8 @@ class Message:
 @dataclass_json
 @dataclass
 class Project:
-    project_id: Optional[str] = ""
-    name: Optional[str] = ""
+    project_id: str = ""
+    name: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -50,7 +50,7 @@ class Project:
 @dataclass_json
 @dataclass
 class ProjectsResponse:
-    projects: Optional[List[Project]] = None
+    projects: List[Project] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -73,10 +73,10 @@ class ProjectsResponse:
 @dataclass_json
 @dataclass
 class Member:
-    email: Optional[str] = ""
-    first_name: Optional[str] = ""
-    last_name: Optional[str] = ""
-    member_id: Optional[str] = ""
+    email: str = ""
+    first_name: str = ""
+    last_name: str = ""
+    member_id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -92,7 +92,7 @@ class Member:
 @dataclass_json
 @dataclass
 class MembersResponse:
-    members: Optional[List[Member]] = None
+    members: List[Member] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -115,10 +115,10 @@ class MembersResponse:
 @dataclass_json
 @dataclass
 class Key:
-    api_key_id: Optional[str] = ""
+    api_key_id: str = ""
     comment: Optional[str] = ""
-    created: Optional[str] = ""
-    scopes: Optional[List[str]] = None
+    created: str = ""
+    scopes: List[str] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -136,8 +136,8 @@ class Key:
 @dataclass_json
 @dataclass
 class KeyResponse:
-    api_key: Optional[Key] = None
-    member: Optional[Member] = None
+    api_key: Key = None
+    member: Member = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -157,7 +157,7 @@ class KeyResponse:
 @dataclass_json
 @dataclass
 class KeysResponse:
-    api_keys: Optional[List[KeyResponse]] = None
+    api_keys: List[KeyResponse] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -180,7 +180,7 @@ class KeysResponse:
 @dataclass_json
 @dataclass
 class ScopesResponse:
-    scopes: Optional[List[str]] = None
+    scopes: List[str] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -201,8 +201,8 @@ class ScopesResponse:
 @dataclass_json
 @dataclass
 class Invite:
-    email: Optional[str] = ""
-    scope: Optional[str] = ""
+    email: str = ""
+    scope: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -218,7 +218,7 @@ class Invite:
 @dataclass_json
 @dataclass
 class InvitesResponse:
-    invites: Optional[List[Invite]] = None
+    invites: List[Invite] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -241,8 +241,8 @@ class InvitesResponse:
 @dataclass_json
 @dataclass
 class Config:
-    language: Optional[str] = ""
-    model: Optional[str] = ""
+    language: str = ""
+    model: str = ""
     punctuate: Optional[bool] = False
     utterances: Optional[bool] = False
     diarize: Optional[bool] = False
@@ -263,16 +263,18 @@ class Config:
 @dataclass_json
 @dataclass
 class Details:
-    usd: Optional[float] = 0
-    duration: Optional[float] = 0
-    total_audio: Optional[float] = 0
-    channels: Optional[int] = 0
-    streams: Optional[int] = 0
-    method: Optional[str] = ""
-    models: Optional[List[str]] = None
-    tags: Optional[List[str]] = None
-    features: Optional[List[str]] = None
-    config: Optional[Config] = None
+    usd: float = 0
+    duration: float = 0
+    total_audio: float = 0
+    channels: int = 0
+    streams: int = 0
+    method: str = ""
+    models: List[str] = None
+    tags: Optional[List[str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    features: List[str] = None
+    config: Config = None
     tier: Optional[str] = ""
 
     def __getitem__(self, key):
@@ -297,9 +299,9 @@ class Details:
 @dataclass_json
 @dataclass
 class Callback:
-    attempts: Optional[int] = 0
-    code: Optional[int] = 0
-    completed: Optional[str] = ""
+    attempts: int = 0
+    code: int = 0
+    completed: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -315,10 +317,10 @@ class Callback:
 @dataclass_json
 @dataclass
 class TokenDetail:
-    feature: Optional[str] = ""
-    input: Optional[int] = 0
-    model: Optional[str] = ""
-    output: Optional[int] = 0
+    feature: str = ""
+    input: int = 0
+    model: str = ""
+    output: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -334,10 +336,10 @@ class TokenDetail:
 @dataclass_json
 @dataclass
 class Response:
-    code: Optional[int] = 0
-    completed: Optional[str] = ""
-    details: Optional[Details] = None
-    token_details: Optional[List[TokenDetail]] = None
+    code: int = 0
+    completed: str = ""
+    details: Details = None
+    token_details: List[TokenDetail] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -360,14 +362,18 @@ class Response:
 @dataclass_json
 @dataclass
 class UsageRequest:
-    project_uuid: Optional[str] = ""
-    request_id: Optional[str] = ""
-    created: Optional[str] = ""
-    path: Optional[str] = ""
-    api_key_id: Optional[str] = ""
-    response: Optional[Response] = None
-    callback: Optional[Callback] = None
-    accessor: Optional[str] = ""
+    project_uuid: str = ""
+    request_id: str = ""
+    created: str = ""
+    path: str = ""
+    api_key_id: str = ""
+    response: Response = None
+    callback: Optional[Callback] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    accessor: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -387,9 +393,9 @@ class UsageRequest:
 @dataclass_json
 @dataclass
 class UsageRequestsResponse:
-    page: Optional[int] = 0
-    limit: Optional[int] = 0
-    requests: Optional[List[UsageRequest]] = None
+    page: int = 0
+    limit: int = 0
+    requests: List[UsageRequest] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -409,8 +415,8 @@ class UsageRequestsResponse:
 @dataclass_json
 @dataclass
 class Tokens:
-    tokens_in: Optional[int] = 0
-    out: Optional[int] = 0
+    tokens_in: int = 0
+    out: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -426,12 +432,12 @@ class Tokens:
 @dataclass_json
 @dataclass
 class Results:
-    start: Optional[str] = ""
-    end: Optional[str] = ""
-    hours: Optional[int] = 0
-    total_hours: Optional[int] = 0
-    requests: Optional[int] = 0
-    tokens: Optional[Tokens] = None
+    start: str = ""
+    end: str = ""
+    hours: int = 0
+    total_hours: int = 0
+    requests: int = 0
+    tokens: Tokens = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -449,8 +455,8 @@ class Results:
 @dataclass_json
 @dataclass
 class Resolution:
-    units: Optional[str] = ""
-    amount: Optional[int] = 0
+    units: str = ""
+    amount: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -466,10 +472,10 @@ class Resolution:
 @dataclass_json
 @dataclass
 class UsageSummaryResponse:
-    start: Optional[str] = ""
-    end: Optional[str] = ""
-    resolution: Optional[Resolution] = None
-    results: Optional[List[Results]] = None
+    start: str = ""
+    end: str = ""
+    resolution: Resolution = None
+    results: List[Results] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -491,10 +497,10 @@ class UsageSummaryResponse:
 @dataclass_json
 @dataclass
 class UsageModel:
-    name: Optional[str] = ""
-    language: Optional[str] = ""
-    version: Optional[str] = ""
-    model_id: Optional[str] = ""
+    name: str = ""
+    language: str = ""
+    version: str = ""
+    model_id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -510,11 +516,15 @@ class UsageModel:
 @dataclass_json
 @dataclass
 class UsageFieldsResponse:
-    tags: Optional[List[str]] = None
-    models: Optional[List[UsageModel]] = None
-    processing_methods: Optional[List[str]] = None
-    features: Optional[List[str]] = None
-    languages: Optional[List[str]] = None
+    tags: Optional[List[str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    models: List[UsageModel] = None
+    processing_methods: List[str] = None
+    features: List[str] = None
+    languages: List[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -548,10 +558,10 @@ class UsageFieldsResponse:
 @dataclass_json
 @dataclass
 class Balance:
-    balance_id: Optional[str] = ""
-    amount: Optional[str] = ""
-    units: Optional[str] = ""
-    purchase_order_id: Optional[str] = ""
+    balance_id: str = ""
+    amount: str = ""
+    units: str = ""
+    purchase_order_id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -567,7 +577,7 @@ class Balance:
 @dataclass_json
 @dataclass
 class BalancesResponse:
-    balances: Optional[List[Balance]] = None
+    balances: List[Balance] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/prerecorded/v1/options.py
+++ b/deepgram/clients/prerecorded/v1/options.py
@@ -2,8 +2,8 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from dataclasses import dataclass
-from dataclasses_json import dataclass_json
+from dataclasses import dataclass, field
+from dataclasses_json import dataclass_json, config
 
 from io import BufferedReader
 from typing import Union, List, Optional
@@ -20,43 +20,117 @@ class PrerecordedOptions:
     https://developers.deepgram.com/reference/pre-recorded
     """
 
-    alternatives: Optional[int] = None
-    callback: Optional[str] = None
-    callback_method: Optional[str] = None
-    custom_intent: Optional[Union[list, str]] = None
-    custom_intent_mode: Optional[str] = None
-    custom_topics: Optional[Union[list, str]] = None
-    custom_topic_mode: Optional[str] = None
-    detect_entities: Optional[bool] = None
-    detect_language: Optional[bool] = None
-    detect_topics: Optional[bool] = None
-    diarize: Optional[bool] = None
-    diarize_version: Optional[str] = None
-    dictation: Optional[bool] = None
-    extra: Optional[Union[list, str]] = None
-    filler_words: Optional[bool] = None
-    intents: Optional[bool] = None
-    keywords: Optional[Union[list, str]] = None
-    language: Optional[str] = None
-    measurements: Optional[bool] = None
-    model: Optional[str] = None
-    multichannel: Optional[bool] = None
-    numerals: Optional[bool] = None
-    paragraphs: Optional[bool] = None
-    profanity_filter: Optional[bool] = None
-    punctuate: Optional[bool] = None
-    redact: Optional[Union[List[str], bool, str]] = None
-    replace: Optional[Union[list, str]] = None
-    search: Optional[Union[list, str]] = None
-    sentiment: Optional[bool] = None
-    smart_format: Optional[bool] = None
-    summarize: Optional[Union[bool, str]] = None
-    tag: Optional[list] = None
-    tier: Optional[str] = None
-    topics: Optional[bool] = None
-    utt_split: Optional[int] = None
-    utterances: Optional[bool] = None
-    version: Optional[str] = None
+    alternatives: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    callback: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    callback_method: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_intent: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_intent_mode: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_topics: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    custom_topic_mode: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    detect_entities: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    detect_language: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    detect_topics: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    diarize: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    diarize_version: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    dictation: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    extra: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    filler_words: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    intents: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    keywords: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    language: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    measurements: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    model: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    multichannel: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    numerals: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    paragraphs: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    profanity_filter: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    punctuate: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    redact: Optional[Union[List[str], bool, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    replace: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    search: Optional[Union[list, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    sentiment: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    smart_format: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    summarize: Optional[Union[bool, str]] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    tag: Optional[list] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    tier: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    topics: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    utt_split: Optional[int] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    utterances: Optional[bool] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
+    version: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/deepgram/clients/prerecorded/v1/response.py
+++ b/deepgram/clients/prerecorded/v1/response.py
@@ -13,7 +13,7 @@ from ..enums import Sentiment
 @dataclass_json
 @dataclass
 class AsyncPrerecordedResponse:
-    request_id: Optional[str] = ""
+    request_id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -32,9 +32,9 @@ class AsyncPrerecordedResponse:
 @dataclass_json
 @dataclass
 class SummaryInfo:
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
-    model_uuid: Optional[str] = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    model_uuid: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -50,9 +50,9 @@ class SummaryInfo:
 @dataclass_json
 @dataclass
 class ModelInfo:
-    name: Optional[str] = ""
-    version: Optional[str] = ""
-    arch: Optional[str] = ""
+    name: str = ""
+    version: str = ""
+    arch: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -68,9 +68,9 @@ class ModelInfo:
 @dataclass_json
 @dataclass
 class IntentsInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -86,9 +86,9 @@ class IntentsInfo:
 @dataclass_json
 @dataclass
 class SentimentInfo:
-    model_uuid: Optional[str] = 0
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -104,9 +104,9 @@ class SentimentInfo:
 @dataclass_json
 @dataclass
 class TopicsInfo:
-    model_uuid: Optional[str] = ""
-    input_tokens: Optional[int] = 0
-    output_tokens: Optional[int] = 0
+    model_uuid: str = ""
+    input_tokens: int = 0
+    output_tokens: int = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -122,12 +122,12 @@ class TopicsInfo:
 @dataclass_json
 @dataclass
 class Metadata:
-    transaction_key: Optional[str] = ""
-    request_id: Optional[str] = ""
-    sha256: Optional[str] = ""
-    created: Optional[str] = ""
-    duration: Optional[float] = 0
-    channels: Optional[int] = 0
+    transaction_key: str = ""
+    request_id: str = ""
+    sha256: str = ""
+    created: str = ""
+    duration: float = 0
+    channels: int = 0
     models: Optional[List[str]] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -188,9 +188,9 @@ class Metadata:
 @dataclass_json
 @dataclass
 class SummaryV1:
-    summary: Optional[str] = ""
-    start_word: Optional[float] = 0
-    end_word: Optional[float] = 0
+    summary: str = ""
+    start_word: float = 0
+    end_word: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -212,8 +212,8 @@ class Summaries(SummaryV1):  # internal reference to old name
 @dataclass_json
 @dataclass
 class SummaryV2:
-    result: Optional[str] = ""
-    short: Optional[str] = ""
+    result: str = ""
+    short: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -235,9 +235,9 @@ class Summary(SummaryV2):  # internal reference to old name
 @dataclass_json
 @dataclass
 class Hit:
-    confidence: Optional[float] = 0
-    start: Optional[float] = 0
-    end: Optional[float] = 0
+    confidence: float = 0
+    start: float = 0
+    end: float = 0
     snippet: Optional[str] = ""
 
     def __getitem__(self, key):
@@ -254,11 +254,13 @@ class Hit:
 @dataclass_json
 @dataclass
 class Word:
-    word: Optional[str] = ""
-    start: Optional[float] = 0
-    end: Optional[float] = 0
-    confidence: Optional[float] = 0
-    punctuated_word: Optional[str] = ""
+    word: str = ""
+    start: float = 0
+    end: float = 0
+    confidence: float = 0
+    punctuated_word: Optional[str] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
     speaker: Optional[int] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -288,9 +290,9 @@ class Word:
 @dataclass_json
 @dataclass
 class Sentence:
-    text: Optional[str] = ""
-    start: Optional[float] = 0
-    end: Optional[float] = 0
+    text: str = ""
+    start: float = 0
+    end: float = 0
     sentiment: Optional[Sentiment] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -314,12 +316,10 @@ class Sentence:
 @dataclass_json
 @dataclass
 class Paragraph:
-    sentences: Optional[List[Sentence]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    start: Optional[float] = 0
-    end: Optional[float] = 0
-    num_words: Optional[float] = 0
+    sentences: List[Sentence] = None
+    start: float = 0
+    end: float = 0
+    num_words: float = 0
     speaker: Optional[int] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -390,9 +390,9 @@ class Translation:
 @dataclass_json
 @dataclass
 class Warning:
-    parameter: Optional[str] = ""
-    type: Optional[str] = ""
-    message: Optional[str] = ""
+    parameter: str = ""
+    type: str = ""
+    message: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -408,10 +408,8 @@ class Warning:
 @dataclass_json
 @dataclass
 class Search:
-    query: Optional[str] = ""
-    hits: Optional[List[Hit]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    query: str = ""
+    hits: List[Hit] = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -429,14 +427,12 @@ class Search:
 @dataclass_json
 @dataclass
 class Utterance:
-    start: Optional[float] = 0
-    end: Optional[float] = 0
-    confidence: Optional[float] = 0
-    channel: Optional[int] = 0
-    transcript: Optional[str] = ""
-    words: Optional[List[Word]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    start: float = 0
+    end: float = 0
+    confidence: float = 0
+    channel: int = 0
+    transcript: str = ""
+    words: List[Word] = None
     speaker: Optional[int] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -446,7 +442,7 @@ class Utterance:
     sentiment_score: Optional[float] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
-    id: Optional[str] = ""
+    id: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -466,11 +462,11 @@ class Utterance:
 @dataclass_json
 @dataclass
 class Entity:
-    label: Optional[str] = ""
-    value: Optional[str] = ""
-    confidence: Optional[float] = 0
-    start_word: Optional[float] = 0
-    end_word: Optional[float] = 0
+    label: str = ""
+    value: str = ""
+    confidence: float = 0
+    start_word: float = 0
+    end_word: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -486,11 +482,9 @@ class Entity:
 @dataclass_json
 @dataclass
 class Alternative:
-    transcript: Optional[str] = ""
-    confidence: Optional[float] = 0
-    words: Optional[List[Word]] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    transcript: str = ""
+    confidence: float = 0
+    words: List[Word] = None
     summaries: Optional[List[SummaryV1]] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
@@ -538,11 +532,13 @@ class Channel:
     search: Optional[List[Search]] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
-    alternatives: Optional[List[Alternative]] = field(
+    alternatives: List[Alternative] = None
+    detected_language: Optional[str] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
-    detected_language: Optional[str] = ""
-    language_confidence: Optional[float] = 0
+    language_confidence: Optional[float] = field(
+        default=None, metadata=config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -565,8 +561,8 @@ class Channel:
 @dataclass_json
 @dataclass
 class Intent:
-    intent: Optional[str] = ""
-    confidence_score: Optional[float] = 0
+    intent: str = ""
+    confidence_score: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -582,12 +578,8 @@ class Intent:
 @dataclass_json
 @dataclass
 class Average:
-    sentiment: Optional[Sentiment] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
-    sentiment_score: Optional[float] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
-    )
+    sentiment: Sentiment = None
+    sentiment_score: float = None
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -605,8 +597,8 @@ class Average:
 @dataclass_json
 @dataclass
 class Topic:
-    topic: Optional[str] = ""
-    confidence_score: Optional[float] = 0
+    topic: str = ""
+    confidence_score: float = 0
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -622,9 +614,9 @@ class Topic:
 @dataclass_json
 @dataclass
 class Segment:
-    text: Optional[str] = ""
-    start_word: Optional[int] = 0
-    end_word: Optional[int] = 0
+    text: str = ""
+    start_word: int = 0
+    end_word: int = 0
     sentiment: Optional[Sentiment] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )

--- a/examples/manage/usage/main.py
+++ b/examples/manage/usage/main.py
@@ -33,6 +33,7 @@ def main():
             myId = project.project_id
             myName = project.name
             print(f"ListProjects() - ID: {myId}, Name: {myName}")
+            break
 
         # list requests
         requestId = None
@@ -41,9 +42,10 @@ def main():
         if listResp is None:
             print("No requests found")
         else:
+            print(f"GetUsageRequests() - listResp: {listResp}")
             for request in listResp.requests:
                 requestId = request.request_id
-                print(f"GetUsageRequests() - ID: {requestId}, Path: {request.path}")
+                break
         print(f"request_id: {requestId}")
         print("")
 
@@ -52,10 +54,7 @@ def main():
         if reqResp is None:
             print("No request found")
         else:
-            for request in listResp.requests:
-                print(
-                    f"GetUsageRequest() - ID: {request.request_id}, Path: {request.path}"
-                )
+            print(f"GetUsageRequest() - listResp: {listResp}")
         print("")
 
         # get fields
@@ -65,12 +64,7 @@ def main():
             print(f"UsageFields not found.")
             sys.exit(1)
         else:
-            for model in listResp.models:
-                print(
-                    f"GetUsageFields Models - ID: {model.model_id}, Name: {model.name}"
-                )
-            for method in listResp.processing_methods:
-                print(f"GetUsageFields Methods: {method}")
+            print(f"GetUsageFields Models - listResp: {listResp}")
         print("")
 
         # list usage
@@ -79,8 +73,7 @@ def main():
         if listResp is None:
             print("UsageSummary not found")
         else:
-            for item in listResp.results:
-                print(f"GetSummary - {item.requests} Calls/{listResp.resolution.units}")
+            print(f"GetSummary - listResp: {listResp}")
     except Exception as e:
         print(f"Exception: {e}")
 

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -21,8 +21,7 @@ def main():
     try:
         # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
         # config = DeepgramClientOptions(
-        #     verbose=logging.DEBUG,
-        #     options={"keepalive": "true"}
+        #     verbose=logging.DEBUG, options={"keepalive": "true"}
         # )
         # deepgram: DeepgramClient = DeepgramClient("", config)
         # otherwise, use default config


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Addresses issue: https://github.com/deepgram/deepgram-python-sdk/issues/310

~**IMPORTANT**: This builds on top of this PR: https://github.com/deepgram/deepgram-python-sdk/pull/314 and https://github.com/deepgram/deepgram-python-sdk/pull/316. Do not merge until those PRs are merged.~

~For a cleaner diff between this PR and its dependency https://github.com/deepgram/deepgram-python-sdk/pull/316, please look at this compare for convenience:
https://github.com/dvonthenen/deepgram-python-sdk/compare/audit-legacy-v2-syntax...dvonthenen:deepgram-python-sdk:remove-optional-dataclass~

**IMPORTANT IMPLEMENTATION DETAIL TO REVIEWER/USER:** Any parameter on any class that is present when a feature is enabled/disabled, but is missing when a different feature is enabled/disabled, **MUST** be marked `Optional` and will be omitted from the JSON (that's the `field`/`lambda function` stuff you see in the code).

If the removal of property isn't done, this is the *undesired* JSON output that is currently happening:
```
{
    "alternatives": null,
    "callback": null,
    "callback_method": null,
    "custom_intent": null,
    "custom_intent_mode": null,
    "custom_topics": null,
    "custom_topic_mode": null,
    "detect_entities": null,
    "detect_language": null,
    "detect_topics": null,
    "diarize": null,
    "diarize_version": null,
    "dictation": null,
    "extra": null,
    "filler_words": null,
    "intents": null,
    "keywords": null,
    "language": null,
    "measurements": null,
    "model": "nova-2",
    "multichannel": null,
    "numerals": null,
    "paragraphs": null,
    "profanity_filter": null,
    "punctuate": null,
    "redact": null,
    "replace": null,
    "search": null,
    "sentiment": null,
    "smart_format": true,
    "summarize": null,
    "tag": null,
    "tier": null,
    "topics": null,
    "utt_split": null,
    "utterances": null,
    "version": null
}
```

Making the fields optional as in this PR, yields the following:
```
{
    "model": "nova-2",
    "smart_format": true
}
```

Notable changes in this PR:
- All properties in `Option` classes (i.e., the Input options for PreRecorded or Live, for example) are optional since they are only set when needed. Please see above.
- If an object itself is `Optional`, but when the object is present it's properties are required, those properties will be required when looking at the class definition in code. Just explicitly calling this out in order to avoid confusion.

Exercised each of the `examples` and made sure the expected values were there.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

