### PR TITLE
fix: handle socket connection closed error in _signal_exit

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -485,7 +485,11 @@ class AsyncLiveClient:
         self.logger.verbose("closing socket...")
         if self._socket is not None:
             self.logger.verbose("send CloseStream...")
-            await self._socket.send(json.dumps({"type": "CloseStream"}))
+            try:
+                # if the socket connection is closed, the following line might throw an error
+                await self._socket.send(json.dumps({"type": "CloseStream"}))
+            except Exception as e:
+                self.logger.error("Exception in AsyncLiveClient._signal_exit, %s", e)
 
             await asyncio.sleep(0.5)
 

--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -488,8 +488,12 @@ class AsyncLiveClient:
             try:
                 # if the socket connection is closed, the following line might throw an error
                 await self._socket.send(json.dumps({"type": "CloseStream"}))
+            except websockets.exceptions.ConnectionClosedOK as e:
+                self.logger.notice(f"_signal_exit  - connection closed: {e.code}")
+            except websockets.exceptions.WebSocketException as e:
+                self.logger.error(f"_signal_exit - WebSocketException: {str(e)}")
             except Exception as e:
-                self.logger.error("Exception in AsyncLiveClient._signal_exit, %s", e)
+                self.logger.error(f"_signal_exit - Exception: {str(e)}")
 
             await asyncio.sleep(0.5)
 

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -473,7 +473,15 @@ class LiveClient:
         self.logger.notice("closing socket...")
         if self._socket is not None:
             self.logger.notice("sending CloseStream...")
-            self.send(json.dumps({"type": "CloseStream"}))
+            try:
+                # if the socket connection is closed, the following line might throw an error
+                self._socket.send(json.dumps({"type": "CloseStream"}))
+            except websockets.exceptions.ConnectionClosedOK as e:
+                self.logger.notice(f"_signal_exit  - connection closed: {e.code}")
+            except websockets.exceptions.WebSocketException as e:
+                self.logger.error(f"_signal_exit - WebSocketException: {str(e)}")
+            except Exception as e:
+                self.logger.error(f"_signal_exit - Exception: {str(e)}")
 
             time.sleep(0.5)
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
In the `_listening` function, when there's a `WebSocketException`, the following line runs as a part of the error handling procedure.

https://github.com/deepgram/deepgram-python-sdk/blob/d2c43344e723df99468bff161e5e2a1c29600fd8/deepgram/clients/live/v1/async_client.py#L371

Now, the `WebSocketException` might also be caused due to the socket connection breaking. In this case, an error is thrown of the following form

```
future: <Task finished name='Task-291' coro=<AsyncLiveClient._listening() done, defined at /usr/local/lib/python3.12/dist-packages/deepgram/clients/live/v1/async_client.py:171> exception=ConnectionClosedError(Close(code=1011, reason='Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001'), Close(code=1011, reason='Deepgram did not receive audio data or a text message within the timeout window. See https://dpgr.am/net0001'), True)>
```

While handling this exception, the `_signal_exit` function is called, which has the following lines
https://github.com/deepgram/deepgram-python-sdk/blob/d2c43344e723df99468bff161e5e2a1c29600fd8/deepgram/clients/live/v1/async_client.py#L483-L496

In line 488, we're doing a `self._socket.send`, which is bound to fail because the socket connection is closed. This throws an error from the `_signal_exit` method. Since `_signal_exit` is not wrapped in a `try except`, the `_listening` method also throws an error and exits. The following is a sample traceback.

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/dist-packages/deepgram/clients/live/v1/async_client.py", line 287, in _listening
    await self._signal_exit()
  File "/usr/local/lib/python3.12/dist-packages/deepgram/clients/live/v1/async_client.py", line 478, in _signal_exit
    await self._socket.send(json.dumps({"type": "CloseStream"}))
  File "/usr/local/lib/python3.12/dist-packages/websockets/legacy/protocol.py", line 635, in send
    await self.ensure_open()
  File "/usr/local/lib/python3.12/dist-packages/websockets/legacy/protocol.py", line 939, in ensure_open
    raise self.connection_closed_exc()
```

In this PR, I've added a `try except` only around the `self._socket.send`. It might be necessary to add exception handling wherever `_signal_exit` is being called as well, as when `_signal_exit` throws an error, the `while True` loop will exit, and the `listen_thread` will not exist anymore. Therefore any transcripts will not be received for that connection.

Closes #356 

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

