### PR TITLE
Implement Unhandled Events

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -23,8 +23,9 @@ from .client import (
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
-    ErrorResponse,
     CloseResponse,
+    UnhandledResponse,
+    ErrorResponse,
 )
 
 # prerecorded

--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -24,8 +24,9 @@ from .clients import (
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
-    ErrorResponse,
     CloseResponse,
+    ErrorResponse,
+    UnhandledResponse,
 )
 
 # prerecorded

--- a/deepgram/clients/__init__.py
+++ b/deepgram/clients/__init__.py
@@ -16,8 +16,9 @@ from .live import (
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
-    ErrorResponse,
     CloseResponse,
+    ErrorResponse,
+    UnhandledResponse,
 )
 
 # prerecorded

--- a/deepgram/clients/listen.py
+++ b/deepgram/clients/listen.py
@@ -35,11 +35,14 @@ from .live import (
 
 # responses
 from .live import (
+    OpenResponse,
     LiveResultResponse,
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
+    CloseResponse,
     ErrorResponse,
+    UnhandledResponse,
 )
 
 

--- a/deepgram/clients/live/__init__.py
+++ b/deepgram/clients/live/__init__.py
@@ -12,8 +12,9 @@ from .client import (
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
-    ErrorResponse,
     CloseResponse,
+    ErrorResponse,
+    UnhandledResponse,
 )
 
 from ...options import DeepgramClientOptions

--- a/deepgram/clients/live/client.py
+++ b/deepgram/clients/live/client.py
@@ -12,8 +12,9 @@ from .v1.response import (
     MetadataResponse as MetadataResponseLatest,
     SpeechStartedResponse as SpeechStartedResponseLatest,
     UtteranceEndResponse as UtteranceEndResponseLatest,
-    ErrorResponse as ErrorResponseLatest,
     CloseResponse as CloseResponseLatest,
+    ErrorResponse as ErrorResponseLatest,
+    UnhandledResponse as UnhandledResponseLatest,
 )
 
 """
@@ -72,6 +73,14 @@ class UtteranceEndResponse(UtteranceEndResponseLatest):
     pass
 
 
+class CloseResponse(CloseResponseLatest):
+    """
+    pass through for CloseResponse based on API version
+    """
+
+    pass
+
+
 class ErrorResponse(ErrorResponseLatest):
     """
     pass through for ErrorResponse based on API version
@@ -80,9 +89,9 @@ class ErrorResponse(ErrorResponseLatest):
     pass
 
 
-class CloseResponse(CloseResponseLatest):
+class UnhandledResponse(UnhandledResponseLatest):
     """
-    pass through for CloseResponse based on API version
+    pass through for UnhandledResponse based on API version
     """
 
     pass

--- a/deepgram/clients/live/enums.py
+++ b/deepgram/clients/live/enums.py
@@ -17,4 +17,5 @@ class LiveTranscriptionEvents(str, Enum):
     UtteranceEnd: str = "UtteranceEnd"
     SpeechStarted: str = "SpeechStarted"
     Error: str = "Error"
+    Unhandled: str = "Unhandled"
     Warning: str = "Warning"

--- a/deepgram/clients/live/v1/__init__.py
+++ b/deepgram/clients/live/v1/__init__.py
@@ -12,6 +12,7 @@ from .response import (
     MetadataResponse,
     SpeechStartedResponse,
     UtteranceEndResponse,
-    ErrorResponse,
     CloseResponse,
+    ErrorResponse,
+    UnhandledResponse,
 )

--- a/deepgram/clients/live/v1/response.py
+++ b/deepgram/clients/live/v1/response.py
@@ -291,6 +291,29 @@ class UtteranceEndResponse:
         return self.to_json(indent=4)
 
 
+# Close Message
+
+
+@dataclass_json
+@dataclass
+class CloseResponse:
+    """
+    Close Message from the Deepgram Platform
+    """
+
+    type: str = ""
+
+    def __getitem__(self, key):
+        _dict = self.to_dict()
+        return _dict[key]
+
+    def __setitem__(self, key, val):
+        self.__dict__[key] = val
+
+    def __str__(self) -> str:
+        return self.to_json(indent=4)
+
+
 # Error Message
 
 
@@ -317,14 +340,18 @@ class ErrorResponse:
         return self.to_json(indent=4)
 
 
+# Unhandled Message
+
+
 @dataclass_json
 @dataclass
-class CloseResponse:
+class UnhandledResponse:
     """
-    Close Message from the Deepgram Platform
+    Unhandled Message from the Deepgram Platform
     """
 
     type: str = ""
+    raw: str = ""
 
     def __getitem__(self, key):
         _dict = self.to_dict()

--- a/examples/advanced/streaming/mute-microphone/main.py
+++ b/examples/advanced/streaming/mute-microphone/main.py
@@ -52,19 +52,19 @@ def main():
         def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
-        def on_error(self, error, **kwargs):
-            print(f"\n\n{error}\n\n")
-
         def on_close(self, close, **kwargs):
             print(f"\n\n{close}\n\n")
+
+        def on_error(self, error, **kwargs):
+            print(f"\n\n{error}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
 
         options: LiveOptions = LiveOptions(
             model="nova-2",

--- a/examples/streaming/async_http/main.py
+++ b/examples/streaming/async_http/main.py
@@ -63,19 +63,23 @@ async def main():
         async def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
-        async def on_error(self, error, **kwargs):
+        def on_close(self, close, **kwargs):
+            print(f"\n\n{close}\n\n")
+
+        def on_error(self, error, **kwargs):
             print(f"\n\n{error}\n\n")
 
-        async def on_close(self, close, **kwargs):
-            print(f"\n\n{close}\n\n")
+        def on_unhandled(self, unhandled, **kwargs):
+            print(f"\n\n{unhandled}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
 
         # connect to websocket
         options: LiveOptions = LiveOptions(

--- a/examples/streaming/async_microphone/main.py
+++ b/examples/streaming/async_microphone/main.py
@@ -59,19 +59,23 @@ async def main():
         async def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
-        async def on_error(self, error, **kwargs):
+        def on_close(self, close, **kwargs):
+            print(f"\n\n{close}\n\n")
+
+        def on_error(self, error, **kwargs):
             print(f"\n\n{error}\n\n")
 
-        async def on_close(self, close, **kwargs):
-            print(f"\n\n{close}\n\n")
+        def on_unhandled(self, unhandled, **kwargs):
+            print(f"\n\n{unhandled}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
 
         # connect to websocket
         options: LiveOptions = LiveOptions(

--- a/examples/streaming/http/main.py
+++ b/examples/streaming/http/main.py
@@ -49,19 +49,23 @@ def main():
         def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
+        def on_close(self, close, **kwargs):
+            print(f"\n\n{close}\n\n")
+
         def on_error(self, error, **kwargs):
             print(f"\n\n{error}\n\n")
 
-        def on_close(self, close, **kwargs):
-            print(f"\n\n{close}\n\n")
+        def on_unhandled(self, unhandled, **kwargs):
+            print(f"\n\n{unhandled}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
 
         # connect to websocket
         options = LiveOptions(model="nova-2", language="en-US")

--- a/examples/streaming/legacy_dict_microphone/main.py
+++ b/examples/streaming/legacy_dict_microphone/main.py
@@ -48,19 +48,23 @@ def main():
         def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
+        def on_close(self, close, **kwargs):
+            print(f"\n\n{close}\n\n")
+
         def on_error(self, error, **kwargs):
             print(f"\n\n{error}\n\n")
 
-        def on_close(self, close, **kwargs):
-            print(f"\n\n{close}\n\n")
+        def on_unhandled(self, unhandled, **kwargs):
+            print(f"\n\n{unhandled}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
 
         options = {
             "model": "nova-2",

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -47,19 +47,23 @@ def main():
         def on_utterance_end(self, utterance_end, **kwargs):
             print(f"\n\n{utterance_end}\n\n")
 
+        def on_close(self, close, **kwargs):
+            print(f"\n\n{close}\n\n")
+
         def on_error(self, error, **kwargs):
             print(f"\n\n{error}\n\n")
 
-        def on_close(self, close, **kwargs):
-            print(f"\n\n{close}\n\n")
+        def on_unhandled(self, unhandled, **kwargs):
+            print(f"\n\n{unhandled}\n\n")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
         dg_connection.on(LiveTranscriptionEvents.Metadata, on_metadata)
         dg_connection.on(LiveTranscriptionEvents.SpeechStarted, on_speech_started)
         dg_connection.on(LiveTranscriptionEvents.UtteranceEnd, on_utterance_end)
-        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
         dg_connection.on(LiveTranscriptionEvents.Close, on_close)
+        dg_connection.on(LiveTranscriptionEvents.Error, on_error)
+        dg_connection.on(LiveTranscriptionEvents.Unhandled, on_unhandled)
 
         options: LiveOptions = LiveOptions(
             model="nova-2",


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This implements an `unhandled` event type. If there is a new event type encountered that the SDK currently doesn't implement, this will fire off a "unhandled' event type and just return the raw JSON to the user through this event. The idea is that the user can take this raw JSON and handle the event themselves until the event is supported in the SDK.

This is already implemented in the Go SDK:
https://github.com/deepgram/deepgram-go-sdk/blob/main/pkg/api/live/v1/interfaces/interfaces.go#L18


Also a slight addition for this PR that was submitted by a member in the community that was just merged:
https://github.com/deepgram/deepgram-python-sdk/pull/355

For the fix above, the emit close event needs to be before triggering the disconnect on the `set()` function. Otherwise, the event will not fire.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

