### PR TITLE
Handle NoneType exit event

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -184,7 +184,7 @@ class AsyncLiveClient:
 
         while True:
             try:
-                if self._exit_event.is_set():
+                if self._exit_event is not None and self._exit_event.is_set():
                     self.logger.notice("_listening exiting gracefully")
                     self.logger.debug("AsyncLiveClient._listening LEAVE")
                     return
@@ -336,7 +336,7 @@ class AsyncLiveClient:
                 counter += 1
                 await asyncio.sleep(ONE_SECOND)
 
-                if self._exit_event.is_set():
+                if self._exit_event is not None and self._exit_event.is_set()::
                     self.logger.notice("_keep_alive exiting gracefully")
                     self.logger.debug("AsyncLiveClient._keep_alive LEAVE")
                     return
@@ -409,7 +409,7 @@ class AsyncLiveClient:
         """
         self.logger.spam("AsyncLiveClient.send ENTER")
 
-        if self._exit_event.is_set():
+        if self._exit_event is not None and self._exit_event.is_set():
             self.logger.notice("send exiting gracefully")
             self.logger.debug("AsyncLiveClient.send LEAVE")
             return False

--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -336,7 +336,7 @@ class AsyncLiveClient:
                 counter += 1
                 await asyncio.sleep(ONE_SECOND)
 
-                if self._exit_event is not None and self._exit_event.is_set()::
+                if self._exit_event is not None and self._exit_event.is_set():
                     self.logger.notice("_keep_alive exiting gracefully")
                     self.logger.debug("AsyncLiveClient._keep_alive LEAVE")
                     return

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -184,7 +184,7 @@ class LiveClient:
 
         while True:
             try:
-                if self._exit_event.is_set():
+                if self._exit_event is not None and self._exit_event.is_set():
                     self.logger.notice("_listening exiting gracefully")
                     self.logger.debug("LiveClient._listening LEAVE")
                     return
@@ -336,7 +336,7 @@ class LiveClient:
                 counter += 1
 
                 self._exit_event.wait(timeout=ONE_SECOND)
-                if self._exit_event.is_set():
+                if self._exit_event is not None and self._exit_event.is_set():
                     self.logger.notice("_keep_alive exiting gracefully")
                     self.logger.debug("LiveClient._keep_alive LEAVE")
                     return
@@ -407,7 +407,7 @@ class LiveClient:
         """
         self.logger.spam("LiveClient.send ENTER")
 
-        if self._exit_event.is_set():
+        if self._exit_event is not None and self._exit_event.is_set():
             self.logger.notice("send exiting gracefully")
             self.logger.debug("AsyncLiveClient.send LEAVE")
             return False


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Fix a bug where `is_set()` is being called on `self._exit_event` when it has a value of `None`, causing an `AttributeError` that bubbles up as an error in application code. To fix, require that `self._exit_event is not None` before calling `self._exit_event.is_set()`.

I do also see in other spots that events are being initialized as `asyncio.Event()`. Should the exit event be instantiated as `self._exit_event = asyncio.Event()` instead of `self._exit_event = None`, so `self._exit_event` is never `None` in the first place?

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

