### PR TITLE
Reset Exit Signal. Do Not Delete Signal.

### DIFF
--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -50,7 +50,7 @@ class AsyncLiveClient:
         self.config = config
         self.endpoint = "v1/listen"
         self._socket = None
-        self._exit_event = None
+        self._exit_event = asyncio.Event()
         self._event_handlers = {event: [] for event in LiveTranscriptionEvents}
         self.websocket_url = convert_to_websocket_url(self.config.url, self.endpoint)
 
@@ -123,7 +123,7 @@ class AsyncLiveClient:
                 extra_headers=combined_headers,
                 ping_interval=PING_INTERVAL,
             )
-            self._exit_event = asyncio.Event()
+            self._exit_event.clear()
 
             # listen thread
             self._listen_thread = asyncio.create_task(self._listening())
@@ -184,7 +184,7 @@ class AsyncLiveClient:
 
         while True:
             try:
-                if self._exit_event is not None and self._exit_event.is_set():
+                if self._exit_event.is_set():
                     self.logger.notice("_listening exiting gracefully")
                     self.logger.debug("AsyncLiveClient._listening LEAVE")
                     return
@@ -336,7 +336,7 @@ class AsyncLiveClient:
                 counter += 1
                 await asyncio.sleep(ONE_SECOND)
 
-                if self._exit_event is not None and self._exit_event.is_set():
+                if self._exit_event.is_set():
                     self.logger.notice("_keep_alive exiting gracefully")
                     self.logger.debug("AsyncLiveClient._keep_alive LEAVE")
                     return
@@ -409,7 +409,7 @@ class AsyncLiveClient:
         """
         self.logger.spam("AsyncLiveClient.send ENTER")
 
-        if self._exit_event is not None and self._exit_event.is_set():
+        if self._exit_event.is_set():
             self.logger.notice("send exiting gracefully")
             self.logger.debug("AsyncLiveClient.send LEAVE")
             return False


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This builds on this PR https://github.com/deepgram/deepgram-python-sdk/pull/365. We shouldn't be deleting the signal exit event because this can cause a race condition. This should be set once and on connect, this event should be cleared. This is to support client reuse. This matches functionality in the .NET and Go SDK.

Tested on examples, edge cases, and expected failures unit tests.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA
