### PR TITLE
Make `nova-2` and `aura-asteria-en` the Default Models

### DIFF
--- a/deepgram/clients/live/v1/options.py
+++ b/deepgram/clients/live/v1/options.py
@@ -58,7 +58,7 @@ class LiveOptions:
         default=None, metadata=config(exclude=lambda f: f is None)
     )
     model: Optional[str] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
+        default="nova-2", metadata=config(exclude=lambda f: f is None)
     )
     multichannel: Optional[bool] = field(
         default=None, metadata=config(exclude=lambda f: f is None)

--- a/deepgram/clients/prerecorded/v1/options.py
+++ b/deepgram/clients/prerecorded/v1/options.py
@@ -85,7 +85,7 @@ class PrerecordedOptions:
         default=None, metadata=config(exclude=lambda f: f is None)
     )
     model: Optional[str] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
+        default="nova-2", metadata=config(exclude=lambda f: f is None)
     )
     multichannel: Optional[bool] = field(
         default=None, metadata=config(exclude=lambda f: f is None)

--- a/deepgram/clients/speak/v1/options.py
+++ b/deepgram/clients/speak/v1/options.py
@@ -21,7 +21,7 @@ class SpeakOptions:
     """
 
     model: Optional[str] = field(
-        default=None, metadata=config(exclude=lambda f: f is None)
+        default="aura-asteria-en", metadata=config(exclude=lambda f: f is None)
     )
     encoding: Optional[str] = field(
         default=None, metadata=config(exclude=lambda f: f is None)

--- a/examples/advanced/prerecorded/direct_invocation/main.py
+++ b/examples/advanced/prerecorded/direct_invocation/main.py
@@ -28,7 +28,7 @@ def main():
 
         # STEP 2 Call the transcribe_url method on the prerecorded class
         options: PrerecordedOptions = PrerecordedOptions(
-            model="nova",
+            model="nova-2",
             smart_format=True,
             summarize="v2",
         )

--- a/examples/prerecorded/async_url/main.py
+++ b/examples/prerecorded/async_url/main.py
@@ -16,7 +16,7 @@ AUDIO_URL = {
 }
 
 options: PrerecordedOptions = PrerecordedOptions(
-    model="nova",
+    model="nova-2",
     smart_format=True,
     summarize="v2",
 )

--- a/examples/prerecorded/file/main.py
+++ b/examples/prerecorded/file/main.py
@@ -39,7 +39,7 @@ def main():
         }
 
         options: PrerecordedOptions = PrerecordedOptions(
-            model="nova",
+            model="nova-2",
             smart_format=True,
             utterances=True,
             punctuate=True,

--- a/examples/prerecorded/stream_file/main.py
+++ b/examples/prerecorded/stream_file/main.py
@@ -40,7 +40,7 @@ def main():
         }
 
         options = PrerecordedOptions(
-            model="nova",
+            model="nova-2",
         )
 
         response = deepgram.listen.prerecorded.v("1").transcribe_file(payload, options)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
If a model is not specified, use `nova-2`  and `aura-asteria-en` as the default models for STT and TTS respectively. This is needed in order to make `vocode` integration a little easier, plus there isn't any inherent problem with defaulting to `nova-2`.

Also, updated all examples to use `nova-2`.

Tested to make sure the default is set correctly and examples still work.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA
