### PR TITLE
Update Examples to Always Display UtteranceEnd Even If Not Using to Process Transcription

### DIFF
--- a/examples/streaming/async_microphone/main.py
+++ b/examples/streaming/async_microphone/main.py
@@ -21,6 +21,7 @@ load_dotenv()
 # We will collect the is_final=true messages here so we can use them when the person finishes speaking
 is_finals = []
 
+
 async def main():
     try:
         loop = asyncio.get_event_loop()
@@ -44,7 +45,7 @@ async def main():
         dg_connection = deepgram.listen.asynclive.v("1")
 
         async def on_open(self, open, **kwargs):
-            print(f"Deepgram Connection Open")
+            print(f"Connection Open")
 
         async def on_message(self, result, **kwargs):
             global is_finals
@@ -59,7 +60,7 @@ async def main():
                 # Speech Final means we have detected sufficent silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
-                    utterance = ' '.join(is_finals)
+                    utterance = " ".join(is_finals)
                     print(f"Speech Final: {utterance}")
                     is_finals = []
                 else:
@@ -70,26 +71,27 @@ async def main():
                 print(f"Interim Results: {sentence}")
 
         async def on_metadata(self, metadata, **kwargs):
-            print(f"Deepgram Metadata: {metadata}")
+            print(f"Metadata: {metadata}")
 
         async def on_speech_started(self, speech_started, **kwargs):
-            print(f"Deepgram Speech Started")
+            print(f"Speech Started")
 
         async def on_utterance_end(self, utterance_end, **kwargs):
+            print(f"Utterance End")
             global is_finals
             if len(is_finals) > 0:
-                utterance = ' '.join(is_finals)
-                print(f"Deepgram Utterance End: {utterance}")
+                utterance = " ".join(is_finals)
+                print(f"Utterance End: {utterance}")
                 is_finals = []
 
         async def on_close(self, close, **kwargs):
-            print(f"Deepgram Connection Closed")
+            print(f"Connection Closed")
 
         async def on_error(self, error, **kwargs):
-            print(f"Deepgram Handled Error: {error}")
+            print(f"Handled Error: {error}")
 
         async def on_unhandled(self, unhandled, **kwargs):
-            print(f"Deepgram Unhandled Websocket Message: {unhandled}")
+            print(f"Unhandled Websocket Message: {unhandled}")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
@@ -115,7 +117,7 @@ async def main():
             utterance_end_ms="1000",
             vad_events=True,
             # Time in milliseconds of silence to wait for before finalizing speech
-            endpointing=300
+            endpointing=300,
         )
 
         addons = {

--- a/examples/streaming/microphone/main.py
+++ b/examples/streaming/microphone/main.py
@@ -19,6 +19,7 @@ load_dotenv()
 # We will collect the is_final=true messages here so we can use them when the person finishes speaking
 is_finals = []
 
+
 def main():
     try:
         # example of setting up a client config. logging values: WARNING, VERBOSE, DEBUG, SPAM
@@ -32,7 +33,7 @@ def main():
         dg_connection = deepgram.listen.live.v("1")
 
         def on_open(self, open, **kwargs):
-            print(f"Deepgram Connection Open")
+            print(f"Connection Open")
 
         def on_message(self, result, **kwargs):
             global is_finals
@@ -47,7 +48,7 @@ def main():
                 # Speech Final means we have detected sufficent silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
-                    utterance = ' '.join(is_finals)
+                    utterance = " ".join(is_finals)
                     print(f"Speech Final: {utterance}")
                     is_finals = []
                 else:
@@ -58,26 +59,27 @@ def main():
                 print(f"Interim Results: {sentence}")
 
         def on_metadata(self, metadata, **kwargs):
-            print(f"Deepgram Metadata: {metadata}")
+            print(f"Metadata: {metadata}")
 
         def on_speech_started(self, speech_started, **kwargs):
-            print(f"Deepgram Speech Started")
+            print(f"Speech Started")
 
         def on_utterance_end(self, utterance_end, **kwargs):
+            print(f"Utterance End")
             global is_finals
             if len(is_finals) > 0:
-                utterance = ' '.join(is_finals)
-                print(f"Deepgram Utterance End: {utterance}")
+                utterance = " ".join(is_finals)
+                print(f"Utterance End: {utterance}")
                 is_finals = []
 
         def on_close(self, close, **kwargs):
-            print(f"Deepgram Connection Closed")
+            print(f"Connection Closed")
 
         def on_error(self, error, **kwargs):
-            print(f"Deepgram Handled Error: {error}")
+            print(f"Handled Error: {error}")
 
         def on_unhandled(self, unhandled, **kwargs):
-            print(f"Deepgram Unhandled Websocket Message: {unhandled}")
+            print(f"Unhandled Websocket Message: {unhandled}")
 
         dg_connection.on(LiveTranscriptionEvents.Open, on_open)
         dg_connection.on(LiveTranscriptionEvents.Transcript, on_message)
@@ -102,7 +104,7 @@ def main():
             utterance_end_ms="1000",
             vad_events=True,
             # Time in milliseconds of silence to wait for before finalizing speech
-            endpointing=300
+            endpointing=300,
         )
 
         addons = {


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
To some it isn't clear the event is being fired. This displays receiving the event even if it doesn't contribute to the transcription processing.

Syntac updates for Black Formatter (would be good to have that automation in place right?)

Removed "Deepgram "  from each event name. Doesn't add value. Of course it's Deepgram, what else would it be?

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA
