### PR TITLE
Change utt_split type to float

### DIFF
--- a/deepgram/clients/prerecorded/v1/options.py
+++ b/deepgram/clients/prerecorded/v1/options.py
@@ -132,7 +132,7 @@ class PrerecordedOptions:
     topics: Optional[bool] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
-    utt_split: Optional[int] = field(
+    utt_split: Optional[float] = field(
         default=None, metadata=config(exclude=lambda f: f is None)
     )
     utterances: Optional[bool] = field(


### PR DESCRIPTION
The [docs](https://developers.deepgram.com/docs/utterance-split#enable-feature) show that `utt_split` is actually a float value, so I think this type should be changed.

I tested this change by printing out `_url` in `abstract_sync_client.py > _handle_request()`, and then making Prerecorded requests with and without this change. For `utt_split` values of `0.001`, `2`, and `1.01000`, the `_url` was the same with and without this change.

In other words, this change seems to be a functional no-op and is just documentation.