### PR TITLE
Clarify Example Support for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,11 @@ print("Finished")
 
 There are examples for **every** API call in this SDK. You can find all of these examples in the [examples folder](https://github.com/deepgram/deepgram-python-sdk/tree/main/examples) at the root of this repo.
 
-These examples provide:
+Before running any of these examples, then you need to take a look at the README and install the following dependencies:
+
+```bash
+pip install -r examples/requirements-examples.txt
+```
 
 Text to Speech:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,6 +13,8 @@ In order to run the code in the `examples` folder, you first need to:
 pip install -r requirements-examples.txt
 ```
 
+| **IMPORTANT:** The microphone examples may not work out-of-the-box on Windows due to the portaudio dependency. Modifications to the example code and correct installation/configuration of the portaudio library are required.
+
 ## Steps to Test Your Code
 
 If you are contributing changes to this SDK, you can test those changes by using the `prerecorded`, `streaming`, or `manage` "hello world"-style applications in the `examples` folder. Here are the steps to follow:

--- a/examples/streaming/async_microphone/README.md
+++ b/examples/streaming/async_microphone/README.md
@@ -1,10 +1,10 @@
 # Live API (Real-Time) Example
 
-This example uses the Microphone as input in order to detect conversation insights in what is being said. This example required additional components (for the microphone) to be installed in order for this example to function correctly.
+This example uses the Microphone to perform real-time transcription. This example required additional components (for the microphone) to be installed in order for this example to function correctly.
 
 ## Prerequisites
 
-This example will only work on Linux and MacOS. Windows platforms are not supported.
+This example will only work on Linux and macOS. Windows platforms are not supported.
 
 ## Configuration
 

--- a/examples/streaming/legacy_dict_microphone/README.md
+++ b/examples/streaming/legacy_dict_microphone/README.md
@@ -1,6 +1,10 @@
 # Live API (Real-Time) Example
 
-This example uses the Microphone as input in order to detect conversation insights in what is being said. This example required additional components (for the microphone) to be installed in order for this example to function correctly. 
+This example uses the Microphone to perform real-time transcription. This example required additional components (for the microphone) to be installed in order for this example to function correctly.
+
+## Prerequisites
+
+This example will only work on Linux and macOS. Windows platforms are not supported.
 
 ## Configuration
 

--- a/examples/streaming/microphone/README.md
+++ b/examples/streaming/microphone/README.md
@@ -1,10 +1,10 @@
 # Live API (Real-Time) Example
 
-This example uses the Microphone as input in order to detect conversation insights in what is being said. This example required additional components (for the microphone) to be installed in order for this example to function correctly.
+This example uses the Microphone to perform real-time transcription. This example required additional components (for the microphone) to be installed in order for this example to function correctly.
 
 ## Prerequisites
 
-This example will only work on Linux and MacOS. Windows platforms are not supported.
+This example will only work on Linux and macOS. Windows platforms are not supported.
 
 ## Configuration
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses: https://github.com/deepgram/deepgram-python-sdk/issues/340

This clarifies the local Microphone example support for Windows. Since they are only examples and best effort because the portaudio installation (which the user is responsible for) is a little tricky.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added instructions to install dependencies before running examples in the main README.
  - Included a note about potential issues with microphone examples on Windows due to portaudio dependency in the examples README.
  - Updated `legacy_dict_microphone` example README to specify it only works on Linux and macOS.
  - Standardized platform names from "MacOS" to "macOS" in the `async_microphone` and `microphone` example READMEs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->