### PR TITLE
Fix Import of Verboselogs Package Dependency

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -6,7 +6,22 @@
 __version__ = "0.0.0"
 
 # entry point for the deepgram python sdk
-from .client import verboselogs
+import logging
+from .utils import VerboseLogger
+from .utils import (
+    NOTICE,
+    SPAM,
+    SUCCESS,
+    VERBOSE,
+    WARNING,
+    ERROR,
+    FATAL,
+    CRITICAL,
+    INFO,
+    DEBUG,
+    NOTSET,
+)
+
 from .client import Deepgram, DeepgramClient
 from .client import DeepgramClientOptions, ClientOptionsFromEnv
 from .client import DeepgramApiKeyError, DeepgramModuleError

--- a/deepgram/audio/microphone/constants.py
+++ b/deepgram/audio/microphone/constants.py
@@ -2,7 +2,7 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from deepgram.utils import verboselogs
+from ...utils import verboselogs
 
 # Constants for microphone
 

--- a/deepgram/audio/microphone/microphone.py
+++ b/deepgram/audio/microphone/microphone.py
@@ -8,7 +8,7 @@ import threading
 from typing import Optional, Callable
 import logging
 
-from deepgram.utils import verboselogs
+from ...utils import verboselogs
 from .constants import LOGGING, CHANNELS, RATE, CHUNK
 
 

--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -7,7 +7,7 @@ from importlib import import_module
 import os
 
 import logging
-from deepgram.utils import verboselogs
+from .utils import verboselogs
 
 # common
 # pylint: disable=unused-import

--- a/deepgram/clients/analyze/v1/async_client.py
+++ b/deepgram/clients/analyze/v1/async_client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/analyze/v1/client.py
+++ b/deepgram/clients/analyze/v1/client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/analyze/v1/options.py
+++ b/deepgram/clients/analyze/v1/options.py
@@ -2,13 +2,13 @@
 # Use of this source code is governed by a MIT license that can be found in the LICENSE file.
 # SPDX-License-Identifier: MIT
 
-from typing import List, Union, Optional
 import logging
+from typing import List, Union, Optional
 
 from dataclasses import dataclass, field
 from dataclasses_json import config as dataclass_config, DataClassJsonMixin
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ...common import FileSource, StreamSource, UrlSource
 
 

--- a/deepgram/clients/listen.py
+++ b/deepgram/clients/listen.py
@@ -5,7 +5,7 @@
 from importlib import import_module
 import logging
 
-from deepgram.utils import verboselogs
+from ..utils import verboselogs
 from ..options import DeepgramClientOptions
 from .errors import DeepgramModuleError
 

--- a/deepgram/clients/live/v1/async_client.py
+++ b/deepgram/clients/live/v1/async_client.py
@@ -11,7 +11,7 @@ import threading
 import websockets
 from websockets.client import WebSocketClientProtocol
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ..enums import LiveTranscriptionEvents
 from ..helpers import convert_to_websocket_url, append_query_params

--- a/deepgram/clients/live/v1/client.py
+++ b/deepgram/clients/live/v1/client.py
@@ -11,7 +11,7 @@ import threading
 from websockets.sync.client import connect, ClientConnection
 import websockets
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ..enums import LiveTranscriptionEvents
 from ..helpers import convert_to_websocket_url, append_query_params

--- a/deepgram/clients/manage/v1/async_client.py
+++ b/deepgram/clients/manage/v1/async_client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 

--- a/deepgram/clients/manage/v1/client.py
+++ b/deepgram/clients/manage/v1/client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 

--- a/deepgram/clients/prerecorded/v1/async_client.py
+++ b/deepgram/clients/prerecorded/v1/async_client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/prerecorded/v1/client.py
+++ b/deepgram/clients/prerecorded/v1/client.py
@@ -7,7 +7,7 @@ from typing import Dict, Union, Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/read.py
+++ b/deepgram/clients/read.py
@@ -5,7 +5,7 @@
 from importlib import import_module
 import logging
 
-from deepgram.utils import verboselogs
+from ..utils import verboselogs
 from ..options import DeepgramClientOptions
 from .errors import DeepgramModuleError
 

--- a/deepgram/clients/selfhosted/v1/async_client.py
+++ b/deepgram/clients/selfhosted/v1/async_client.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 

--- a/deepgram/clients/selfhosted/v1/client.py
+++ b/deepgram/clients/selfhosted/v1/client.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 

--- a/deepgram/clients/speak/v1/async_client.py
+++ b/deepgram/clients/speak/v1/async_client.py
@@ -9,7 +9,7 @@ import aiofiles
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_async_client import AbstractAsyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/speak/v1/client.py
+++ b/deepgram/clients/speak/v1/client.py
@@ -8,7 +8,7 @@ import io
 
 import httpx
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ....options import DeepgramClientOptions
 from ...abstract_sync_client import AbstractSyncRestClient
 from ..errors import DeepgramError, DeepgramTypeError

--- a/deepgram/clients/speak/v1/options.py
+++ b/deepgram/clients/speak/v1/options.py
@@ -9,7 +9,7 @@ import logging
 from dataclasses import dataclass, field
 from dataclasses_json import config as dataclass_config, DataClassJsonMixin
 
-from deepgram.utils import verboselogs
+from ....utils import verboselogs
 from ...common import FileSource
 
 

--- a/deepgram/options.py
+++ b/deepgram/options.py
@@ -10,7 +10,7 @@ import logging
 import numbers
 
 from deepgram import __version__
-from deepgram.utils import verboselogs
+from .utils import verboselogs
 from .errors import DeepgramApiKeyError
 
 

--- a/deepgram/utils/__init__.py
+++ b/deepgram/utils/__init__.py
@@ -1,0 +1,19 @@
+# Copyright 2024 Deepgram SDK contributors. All Rights Reserved.
+# Use of this source code is governed by a MIT license that can be found in the LICENSE file.
+# SPDX-License-Identifier: MIT
+
+import logging
+from .verboselogs import VerboseLogger
+from .verboselogs import (
+    NOTICE,
+    SPAM,
+    SUCCESS,
+    VERBOSE,
+    WARNING,
+    ERROR,
+    FATAL,
+    CRITICAL,
+    INFO,
+    DEBUG,
+    NOTSET,
+)


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
This fixes the import of the verbose logs package to resolve the missing dependency. Verified broken in test/dev build `dev.1`.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated import paths for the `verboselogs` module across multiple files to use relative imports. This change improves the maintainability and readability of the codebase.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->