### PR TITLE
Fix endpointing type

### DIFF
--- a/deepgram/clients/listen/v1/websocket/options.py
+++ b/deepgram/clients/listen/v1/websocket/options.py
@@ -41,9 +41,15 @@ class LiveOptions(DataClassJsonMixin):  # pylint: disable=too-many-instance-attr
     encoding: Optional[str] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
-    endpointing: Optional[str] = field(
+    # pylint: disable=W0511
+    # TODO: endpointing's current type previous was `Optional[str]` which is incorrect
+    # for backward compatibility we are keeping it as `Optional[Union[str, bool, int]]`
+    # since it gets translated to a string to be placed as a query parameter, will keep `str` for now
+    # but will change this to `Optional[Union[bool, int]]` in a future release
+    endpointing: Optional[Union[str, bool, int]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
+    # pylint: enable=W0511
     extra: Optional[Union[List[str], str]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses: https://github.com/deepgram/deepgram-python-sdk/issues/428

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated the type of the `endpointing` field in the `LiveOptions` class for backward compatibility. It now supports `Optional[Union[str, bool, int]]`.

- **Documentation**
  - Added comments for future updates regarding the planned type change of the `endpointing` field.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->