### PR TITLE
use an unsecured websocket connection if http:// was specified

### DIFF
--- a/deepgram/clients/listen/v1/helpers.py
+++ b/deepgram/clients/listen/v1/helpers.py
@@ -37,10 +37,16 @@ def convert_to_websocket_url(base_url: str, endpoint: str):
     """
     Converts a URL to a WebSocket URL
     """
+    use_ssl = True  # Default to true
     if re.match(r"^https?://", base_url, re.IGNORECASE):
+        if "http://" in base_url:
+            use_ssl = False  # Override to false if http:// is found
         base_url = base_url.replace("https://", "").replace("http://", "")
     if not re.match(r"^wss?://", base_url, re.IGNORECASE):
-        base_url = "wss://" + base_url
+        if use_ssl:
+            base_url = "wss://" + base_url
+        else:
+            base_url = "ws://" + base_url
     parsed_url = urlparse(base_url)
     domain = parsed_url.netloc
     websocket_url = urlunparse((parsed_url.scheme, domain, endpoint, "", "", ""))


### PR DESCRIPTION
## Proposed changes
The code currently only supports SSL-secured websocket connections, which means the SDK doesn't support testing self-hosted deployments when running on the self-hosted server itself (i.e. `ws://` connections).

This change updates the code to use `ws://` rather than `wss://` when the user specifies `http://` in their `api_url`.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
Tested!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
    - Enhanced WebSocket URL handling to support both secure (wss://) and non-secure (ws://) connections based on the provided base URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->