### PR TITLE
Fix Mismatch Structs on STT REST

### DIFF
--- a/deepgram/__init__.py
+++ b/deepgram/__init__.py
@@ -61,11 +61,8 @@ from .client import (
 )
 from .client import (
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
 )
 from .client import (
     OpenResponse,
@@ -92,6 +89,9 @@ from .client import (
     # ErrorResponse,
     #### unique
     ListenWSMetadata,
+    ListenWSAlternative,
+    ListenWSChannel,
+    ListenWSWord,
 )
 
 # prerecorded
@@ -121,6 +121,8 @@ from .client import (
     SyncPrerecordedResponse,
     #### shared
     # Average,
+    # Alternative,
+    # Channel,
     # Intent,
     # Intents,
     # IntentsInfo,
@@ -132,9 +134,8 @@ from .client import (
     # Topic,
     # Topics,
     # TopicsInfo,
+    # Word,
     #### unique
-    Alternative,
-    Channel,
     Entity,
     Hit,
     ListenRESTMetadata,
@@ -150,7 +151,9 @@ from .client import (
     Translation,
     Utterance,
     Warning,
-    Word,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )
 
 # read

--- a/deepgram/audio/microphone/microphone.py
+++ b/deepgram/audio/microphone/microphone.py
@@ -33,7 +33,7 @@ class Microphone:  # pylint: disable=too-many-instance-attributes
     _is_muted: bool
 
     _asyncio_loop: asyncio.AbstractEventLoop
-    _asyncio_thread: threading.Thread
+    _asyncio_thread: Optional[threading.Thread] = None
     _exit: threading.Event
 
     _push_callback_org: Optional[Callable] = None
@@ -142,6 +142,7 @@ class Microphone:  # pylint: disable=too-many-instance-attributes
             )
         else:
             self._logger.verbose("regular threaded callback")
+            self._asyncio_thread = None
             self._push_callback = self._push_callback_org
 
         self._stream = self._audio.open(
@@ -267,7 +268,7 @@ class Microphone:  # pylint: disable=too-many-instance-attributes
             self._logger.notice("stopping asyncio loop...")
             self._asyncio_loop.call_soon_threadsafe(self._asyncio_loop.stop)
             self._asyncio_thread.join()
-            self._asyncio_thread = None  # type: ignore
+            self._asyncio_thread = None
             self._logger.notice("_asyncio_thread joined")
 
         self._logger.notice("finish succeeded")

--- a/deepgram/client.py
+++ b/deepgram/client.py
@@ -37,11 +37,8 @@ from .clients import (
 )
 from .clients import (
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
 )
 from .clients import (
     OpenResponse,
@@ -86,6 +83,9 @@ from .clients import (
     # UnhandledResponse,
     #### unique
     ListenWSMetadata,
+    ListenWSAlternative,
+    ListenWSChannel,
+    ListenWSWord,
 )
 
 # prerecorded
@@ -154,6 +154,9 @@ from .clients import (
     Translation,
     Utterance,
     Warning,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )
 
 # read

--- a/deepgram/clients/__init__.py
+++ b/deepgram/clients/__init__.py
@@ -31,11 +31,8 @@ from .common import (
 # common (shared between listen rest and websocket)
 from .common import (
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
 )
 from .common import (
     OpenResponse,
@@ -124,6 +121,9 @@ from .listen import (
     Translation,
     Utterance,
     Warning,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )
 
 
@@ -150,6 +150,9 @@ from .listen import (
     # UnhandledResponse,
     #### uniqye
     ListenWSMetadata,
+    ListenWSWord,
+    ListenWSAlternative,
+    ListenWSChannel,
 )
 
 ## clients

--- a/deepgram/clients/common/__init__.py
+++ b/deepgram/clients/common/__init__.py
@@ -16,11 +16,8 @@ from .v1 import (
 from .v1 import (
     BaseResponse as BaseResponseLatest,
     ModelInfo as ModelInfoLatest,
-    Word as WordLatest,
-    Alternative as AlternativeLatest,
     Hit as HitLatest,
     Search as SearchLatest,
-    Channel as ChannelLatest,
 )
 
 # rest
@@ -56,11 +53,8 @@ FileSource = FileSourceLatest
 
 BaseResponse = BaseResponseLatest
 ModelInfo = ModelInfoLatest
-Word = WordLatest
-Alternative = AlternativeLatest
 Hit = HitLatest
 Search = SearchLatest
-Channel = ChannelLatest
 
 Average = AverageLatest
 Intent = IntentLatest

--- a/deepgram/clients/common/v1/__init__.py
+++ b/deepgram/clients/common/v1/__init__.py
@@ -17,11 +17,8 @@ from .options import (
 from .shared_response import (
     BaseResponse,
     ModelInfo,
-    Word,
-    Alternative,
     Hit,
     Search,
-    Channel,
 )
 
 from .rest_response import (

--- a/deepgram/clients/common/v1/shared_response.py
+++ b/deepgram/clients/common/v1/shared_response.py
@@ -59,47 +59,6 @@ class ModelInfo(BaseResponse):
 
 
 @dataclass
-class Word(BaseResponse):
-    """
-    Word object
-    """
-
-    word: str = ""
-    start: float = 0
-    end: float = 0
-    confidence: float = 0
-    punctuated_word: Optional[str] = field(
-        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
-    )
-    speaker: Optional[int] = field(
-        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
-    )
-    language: Optional[str] = field(
-        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
-    )
-
-
-@dataclass
-class Alternative(BaseResponse):
-    """
-    Alternative object
-    """
-
-    transcript: str = ""
-    confidence: float = 0
-    words: List[Word] = field(default_factory=list)
-    languages: Optional[List[str]] = field(
-        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
-    )
-
-    def __getitem__(self, key):
-        _dict = self.to_dict()
-        if "words" in _dict:
-            _dict["words"] = [Word.from_dict(words) for words in _dict["words"]]
-        return _dict[key]
-
-
-@dataclass
 class Hit(BaseResponse):
     """
     The hit information for the response.
@@ -124,27 +83,4 @@ class Search(BaseResponse):
         _dict = self.to_dict()
         if "hits" in _dict:
             _dict["hits"] = [Hit.from_dict(hits) for hits in _dict["hits"]]
-        return _dict[key]
-
-
-@dataclass
-class Channel(BaseResponse):
-    """
-    Channel object
-    """
-
-    search: Optional[List[Search]] = field(
-        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
-    )
-    alternatives: List[Alternative] = field(default_factory=list)
-
-    def __getitem__(self, key):
-        _dict = self.to_dict()
-        if "search" in _dict:
-            _dict["search"] = [Search.from_dict(search) for search in _dict["search"]]
-        if "alternatives" in _dict:
-            _dict["alternatives"] = [
-                Alternative.from_dict(alternatives)
-                for alternatives in _dict["alternatives"]
-            ]
         return _dict[key]

--- a/deepgram/clients/listen/__init__.py
+++ b/deepgram/clients/listen/__init__.py
@@ -52,11 +52,8 @@ from .client import (
     TopicsInfo,
     # between rest and websocket
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
     # unique
     Entity,
     ListenRESTMetadata,
@@ -70,6 +67,9 @@ from .client import (
     Translation,
     Utterance,
     Warning,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )
 
 
@@ -94,6 +94,9 @@ from .client import (
     UnhandledResponse,
     # unique
     ListenWSMetadata,
+    ListenWSWord,
+    ListenWSAlternative,
+    ListenWSChannel,
 )
 
 # clients

--- a/deepgram/clients/listen/client.py
+++ b/deepgram/clients/listen/client.py
@@ -41,11 +41,8 @@ from .v1 import (
     TopicsInfo as TopicsInfoLatest,
     # between rest and websocket
     ModelInfo as ModelInfoLatest,
-    Alternative as AlternativeLatest,
     Hit as HitLatest,
     Search as SearchLatest,
-    Channel as ChannelLatest,
-    Word as WordLatest,
     # unique
     ListenRESTMetadata as ListenRESTMetadataLatest,
     Entity as EntityLatest,
@@ -59,6 +56,9 @@ from .v1 import (
     Translation as TranslationLatest,
     Utterance as UtteranceLatest,
     Warning as WarningLatest,
+    ListenRESTAlternative as ListenRESTAlternativeLatest,
+    ListenRESTChannel as ListenRESTChannelLatest,
+    ListenRESTWord as ListenRESTWordLatest,
 )
 
 # websocket
@@ -80,6 +80,9 @@ from .v1 import (
     ErrorResponse as ErrorResponseLatest,
     UnhandledResponse as UnhandledResponseLatest,
     ListenWSMetadata as ListenWSMetadataLatest,
+    ListenWSAlternative as ListenWSAlternativeLatest,
+    ListenWSChannel as ListenWSChannelLatest,
+    ListenWSWord as ListenWSWordLatest,
 )
 
 # The vX/client.py points to the current supported version in the SDK.
@@ -100,12 +103,9 @@ Topics = TopicsLatest
 TopicsInfo = TopicsInfoLatest
 
 # between rest and websocket
-Alternative = AlternativeLatest
-Channel = ChannelLatest
 Hit = HitLatest
 ModelInfo = ModelInfoLatest
 Search = SearchLatest
-Word = WordLatest
 
 # websocket common
 OpenResponse = OpenResponseLatest
@@ -152,6 +152,9 @@ SummaryV2 = SummaryV2Latest
 Translation = TranslationLatest
 Utterance = UtteranceLatest
 Warning = WarningLatest
+ListenRESTAlternative = ListenRESTAlternativeLatest
+ListenRESTChannel = ListenRESTChannelLatest
+ListenRESTWord = ListenRESTWordLatest
 
 # websocket
 ## input
@@ -166,7 +169,9 @@ UtteranceEndResponse = UtteranceEndResponseLatest
 
 ## unique
 ListenWSMetadata = ListenWSMetadataLatest
-
+ListenWSAlternative = ListenWSAlternativeLatest
+ListenWSChannel = ListenWSChannelLatest
+ListenWSWord = ListenWSWordLatest
 
 # clients
 ListenRESTClient = ListenRESTClientLatest

--- a/deepgram/clients/listen/v1/__init__.py
+++ b/deepgram/clients/listen/v1/__init__.py
@@ -31,11 +31,8 @@ from ...common import (
 # between rest and websocket
 from ...common import (
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
 )
 
 # common websocket
@@ -99,6 +96,9 @@ from .rest import (
     Translation,
     Utterance,
     Warning,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )
 
 # websocket
@@ -125,4 +125,7 @@ from .websocket import (
     # Word,
     #### unique
     Metadata as ListenWSMetadata,
+    ListenWSWord,
+    ListenWSAlternative,
+    ListenWSChannel,
 )

--- a/deepgram/clients/listen/v1/rest/__init__.py
+++ b/deepgram/clients/listen/v1/rest/__init__.py
@@ -38,11 +38,8 @@ from .response import (
     TopicsInfo,
     # between rest and websocket
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
     # unique
     Entity,
     Metadata,
@@ -56,4 +53,7 @@ from .response import (
     Translation,
     Utterance,
     Warning,
+    ListenRESTAlternative,
+    ListenRESTChannel,
+    ListenRESTWord,
 )

--- a/deepgram/clients/listen/v1/rest/response.py
+++ b/deepgram/clients/listen/v1/rest/response.py
@@ -27,11 +27,8 @@ from ....common import (
 # between rest and websocket
 from ....common import (
     ModelInfo,
-    Alternative,
-    Channel,
     Hit,
     Search,
-    Word,
 )
 
 # Async Prerecorded Response Types:
@@ -142,11 +139,24 @@ Summary = SummaryV2
 
 
 @dataclass
-class ListenRestWord(Word):  # pylint: disable=too-many-instance-attributes
+class ListenRESTWord(BaseResponse):  # pylint: disable=too-many-instance-attributes
     """
     The word information for the response.
     """
 
+    word: str = ""
+    start: float = 0
+    end: float = 0
+    confidence: float = 0
+    punctuated_word: Optional[str] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+    speaker: Optional[int] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+    language: Optional[str] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
     speaker_confidence: Optional[float] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
@@ -270,7 +280,7 @@ class Utterance(BaseResponse):  # pylint: disable=too-many-instance-attributes
     confidence: float = 0
     channel: int = 0
     transcript: str = ""
-    words: List[Word] = field(default_factory=list)
+    words: List[ListenRESTWord] = field(default_factory=list)
     speaker: Optional[int] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
@@ -285,7 +295,9 @@ class Utterance(BaseResponse):  # pylint: disable=too-many-instance-attributes
     def __getitem__(self, key):
         _dict = self.to_dict()
         if "words" in _dict:
-            _dict["words"] = [Word.from_dict(words) for words in _dict["words"]]
+            _dict["words"] = [
+                ListenRESTWord.from_dict(words) for words in _dict["words"]
+            ]
         if "sentiment" in _dict:
             _dict["sentiment"] = Sentiment.from_dict(_dict["sentiment"])
         return _dict[key]
@@ -306,12 +318,15 @@ class Entity(BaseResponse):
 
 @dataclass
 class ListenRESTAlternative(
-    Alternative
+    BaseResponse
 ):  # pylint: disable=too-many-instance-attributes
     """
     The alternative information for the response.
     """
 
+    transcript: str = ""
+    confidence: float = 0
+    words: List[ListenRESTWord] = field(default_factory=list)
     summaries: Optional[List[SummaryV1]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
@@ -324,11 +339,16 @@ class ListenRESTAlternative(
     translations: Optional[List[Translation]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
+    languages: Optional[List[str]] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
 
     def __getitem__(self, key):
         _dict = self.to_dict()
         if "words" in _dict:
-            _dict["words"] = [Word.from_dict(words) for words in _dict["words"]]
+            _dict["words"] = [
+                ListenRESTWord.from_dict(words) for words in _dict["words"]
+            ]
         if "summaries" in _dict:
             _dict["summaries"] = [
                 SummaryV1.from_dict(summaries) for summaries in _dict["summaries"]
@@ -348,7 +368,7 @@ class ListenRESTAlternative(
 
 
 @dataclass
-class ListenRESTChannel(Channel):
+class ListenRESTChannel(BaseResponse):
     """
     The channel information for the response.
     """
@@ -356,7 +376,7 @@ class ListenRESTChannel(Channel):
     search: Optional[List[Search]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
-    alternatives: List[Alternative] = field(default_factory=list)
+    alternatives: List[ListenRESTAlternative] = field(default_factory=list)
     detected_language: Optional[str] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
@@ -370,7 +390,7 @@ class ListenRESTChannel(Channel):
             _dict["search"] = [Search.from_dict(search) for search in _dict["search"]]
         if "alternatives" in _dict:
             _dict["alternatives"] = [
-                Alternative.from_dict(alternatives)
+                ListenRESTAlternative.from_dict(alternatives)
                 for alternatives in _dict["alternatives"]
             ]
         return _dict[key]
@@ -382,7 +402,7 @@ class Results(BaseResponse):
     The results information for the response.
     """
 
-    channels: Optional[List[Channel]] = field(
+    channels: Optional[List[ListenRESTChannel]] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
     utterances: Optional[List[Utterance]] = field(
@@ -405,7 +425,7 @@ class Results(BaseResponse):
         _dict = self.to_dict()
         if "channels" in _dict:
             _dict["channels"] = [
-                Channel.from_dict(channels) for channels in _dict["channels"]
+                ListenRESTChannel.from_dict(channels) for channels in _dict["channels"]
             ]
         if "utterances" in _dict:
             _dict["utterances"] = [

--- a/deepgram/clients/listen/v1/websocket/__init__.py
+++ b/deepgram/clients/listen/v1/websocket/__init__.py
@@ -21,11 +21,11 @@ from .response import (
     UnhandledResponse,
     #### between rest and websocket
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
     #### unique
     Metadata,
+    ListenWSWord,
+    ListenWSAlternative,
+    ListenWSChannel,
 )

--- a/deepgram/clients/listen/v1/websocket/response.py
+++ b/deepgram/clients/listen/v1/websocket/response.py
@@ -19,12 +19,77 @@ from ....common import (
 # between rest and websocket
 from ....common import (
     ModelInfo,
-    Alternative,
     Hit,
     Search,
-    Channel,
-    Word,
 )
+
+
+# unique
+
+
+@dataclass
+class ListenWSWord(BaseResponse):
+    """
+    Word object
+    """
+
+    word: str = ""
+    start: float = 0
+    end: float = 0
+    confidence: float = 0
+    punctuated_word: Optional[str] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+    speaker: Optional[int] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+    language: Optional[str] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+
+
+@dataclass
+class ListenWSAlternative(BaseResponse):
+    """
+    Alternative object
+    """
+
+    transcript: str = ""
+    confidence: float = 0
+    words: List[ListenWSWord] = field(default_factory=list)
+    languages: Optional[List[str]] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+
+    def __getitem__(self, key):
+        _dict = self.to_dict()
+        if "words" in _dict:
+            _dict["words"] = [ListenWSWord.from_dict(words) for words in _dict["words"]]
+        return _dict[key]
+
+
+@dataclass
+class ListenWSChannel(BaseResponse):
+    """
+    Channel object
+    """
+
+    search: Optional[List[Search]] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
+    alternatives: List[ListenWSAlternative] = field(default_factory=list)
+
+    def __getitem__(self, key):
+        _dict = self.to_dict()
+        if "search" in _dict:
+            _dict["search"] = [Search.from_dict(search) for search in _dict["search"]]
+        if "alternatives" in _dict:
+            _dict["alternatives"] = [
+                ListenWSAlternative.from_dict(alternatives)
+                for alternatives in _dict["alternatives"]
+            ]
+        return _dict[key]
+
 
 # unique
 
@@ -62,7 +127,7 @@ class LiveResultResponse(BaseResponse):  # pylint: disable=too-many-instance-att
     Result Message from the Deepgram Platform
     """
 
-    channel: Channel
+    channel: ListenWSChannel
     metadata: Metadata
     type: str = ""
     channel_index: List[int] = field(default_factory=list)
@@ -78,7 +143,7 @@ class LiveResultResponse(BaseResponse):  # pylint: disable=too-many-instance-att
         _dict = self.to_dict()
         if "channel" in _dict:
             _dict["channel"] = [
-                Channel.from_dict(channel) for channel in _dict["channel"]
+                ListenWSChannel.from_dict(channel) for channel in _dict["channel"]
             ]
         if "metadata" in _dict:
             _dict["metadata"] = [


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
Addresses: https://github.com/deepgram/deepgram-python-sdk/issues/466

Verified working modifying an example:
`examples/speech-to-text/rest/url`

Options:
```
        options: PrerecordedOptions = PrerecordedOptions(
            model="nova-2",
            smart_format=True,
            paragraphs=True,
        )
```

Result:
```
response: {
    "metadata": {
        "transaction_key": "deprecated",
        "request_id": "3c6973b5-d755-4687-97db-938530c82bd6",
        "sha256": "5324da68ede209a16ac69a38e8cd29cee4d754434a041166cda3a1f5e0b24566",
        "created": "2024-09-26T01:37:48.494Z",
        "duration": 17.566313,
        "channels": 1,
        "models": [
            "30089e05-99d1-4376-b32e-c263170674af"
        ],
        "model_info": {
            "30089e05-99d1-4376-b32e-c263170674af": {
                "name": "2-general-nova",
                "version": "2024-01-09.29447",
                "arch": "nova-2"
            }
        }
    },
    "results": {
        "channels": [
            {
                "alternatives": [
                    {
                        "transcript": "Yep. I said it before, and I'll say it again. Life moves pretty fast. You don't stop and look around once in a while, you could miss it.",
                        "confidence": 0.99853814,
                        "words": [
                            {
                                "word": "yep",
                                "start": 5.52,
                                "end": 6.02,
                                "confidence": 0.995842,
                                "punctuated_word": "Yep."
                            },
                            {
                                "word": "i",
                                "start": 7.04,
                                "end": 7.2799997,
                                "confidence": 0.51270777,
                                "punctuated_word": "I"
                            },
                            {
                                "word": "said",
                                "start": 7.2799997,
                                "end": 7.44,
                                "confidence": 0.96725076,
                                "punctuated_word": "said"
                            },
                            {
                                "word": "it",
                                "start": 7.44,
                                "end": 7.6,
                                "confidence": 0.9997285,
                                "punctuated_word": "it"
                            },
                            {
                                "word": "before",
                                "start": 7.6,
                                "end": 7.9199996,
                                "confidence": 0.7845937,
                                "punctuated_word": "before,"
                            },
                            {
                                "word": "and",
                                "start": 7.9199996,
                                "end": 8.16,
                                "confidence": 0.9998627,
                                "punctuated_word": "and"
                            },
                            {
                                "word": "i'll",
                                "start": 8.16,
                                "end": 8.32,
                                "confidence": 0.9998943,
                                "punctuated_word": "I'll"
                            },
                            {
                                "word": "say",
                                "start": 8.32,
                                "end": 8.48,
                                "confidence": 0.9996518,
                                "punctuated_word": "say"
                            },
                            {
                                "word": "it",
                                "start": 8.48,
                                "end": 8.639999,
                                "confidence": 0.99982834,
                                "punctuated_word": "it"
                            },
                            {
                                "word": "again",
                                "start": 8.639999,
                                "end": 9.139999,
                                "confidence": 0.97370684,
                                "punctuated_word": "again."
                            },
                            {
                                "word": "life",
                                "start": 9.991312,
                                "end": 10.391313,
                                "confidence": 0.99573696,
                                "punctuated_word": "Life"
                            },
                            {
                                "word": "moves",
                                "start": 10.391313,
                                "end": 10.711312,
                                "confidence": 0.9988587,
                                "punctuated_word": "moves"
                            },
                            {
                                "word": "pretty",
                                "start": 10.711312,
                                "end": 11.031313,
                                "confidence": 0.9996013,
                                "punctuated_word": "pretty"
                            },
                            {
                                "word": "fast",
                                "start": 11.031313,
                                "end": 11.531313,
                                "confidence": 0.9995537,
                                "punctuated_word": "fast."
                            },
                            {
                                "word": "you",
                                "start": 12.071312,
                                "end": 12.231313,
                                "confidence": 0.9514584,
                                "punctuated_word": "You"
                            },
                            {
                                "word": "don't",
                                "start": 12.231313,
                                "end": 12.4713125,
                                "confidence": 0.99988735,
                                "punctuated_word": "don't"
                            },
                            {
                                "word": "stop",
                                "start": 12.4713125,
                                "end": 12.711312,
                                "confidence": 0.99979633,
                                "punctuated_word": "stop"
                            },
                            {
                                "word": "and",
                                "start": 12.711312,
                                "end": 12.871312,
                                "confidence": 0.9987136,
                                "punctuated_word": "and"
                            },
                            {
                                "word": "look",
                                "start": 12.871312,
                                "end": 13.031313,
                                "confidence": 0.9996673,
                                "punctuated_word": "look"
                            },
                            {
                                "word": "around",
                                "start": 13.031313,
                                "end": 13.351313,
                                "confidence": 0.9995766,
                                "punctuated_word": "around"
                            },
                            {
                                "word": "once",
                                "start": 13.351313,
                                "end": 13.591312,
                                "confidence": 0.9981976,
                                "punctuated_word": "once"
                            },
                            {
                                "word": "in",
                                "start": 13.591312,
                                "end": 13.751312,
                                "confidence": 0.99853814,
                                "punctuated_word": "in"
                            },
                            {
                                "word": "a",
                                "start": 13.751312,
                                "end": 13.831312,
                                "confidence": 0.9861081,
                                "punctuated_word": "a"
                            },
                            {
                                "word": "while",
                                "start": 13.831312,
                                "end": 14.331312,
                                "confidence": 0.92629486,
                                "punctuated_word": "while,"
                            },
                            {
                                "word": "you",
                                "start": 14.631312,
                                "end": 14.791312,
                                "confidence": 0.99702364,
                                "punctuated_word": "you"
                            },
                            {
                                "word": "could",
                                "start": 14.791312,
                                "end": 14.951313,
                                "confidence": 0.9983536,
                                "punctuated_word": "could"
                            },
                            {
                                "word": "miss",
                                "start": 14.951313,
                                "end": 15.191313,
                                "confidence": 0.9984425,
                                "punctuated_word": "miss"
                            },
                            {
                                "word": "it",
                                "start": 15.191313,
                                "end": 15.691313,
                                "confidence": 0.9950415,
                                "punctuated_word": "it."
                            }
                        ],
                        "paragraphs": {
                            "transcript": "\nYep. I said it before, and I'll say it again. Life moves pretty fast. You don't stop and look around once in a while, you could miss it.",
                            "paragraphs": [
                                {
                                    "sentences": [
                                        {
                                            "text": "Yep.",
                                            "start": 5.52,
                                            "end": 6.02
                                        },
                                        {
                                            "text": "I said it before, and I'll say it again.",
                                            "start": 7.04,
                                            "end": 9.139999
                                        },
                                        {
                                            "text": "Life moves pretty fast.",
                                            "start": 9.991312,
                                            "end": 11.531313
                                        },
                                        {
                                            "text": "You don't stop and look around once in a while, you could miss it.",
                                            "start": 12.071312,
                                            "end": 15.691313
                                        }
                                    ],
                                    "start": 5.52,
                                    "end": 15.691313,
                                    "num_words": 28
                                }
                            ]
                        }
                    }
                ]
            }
        ]
    }
}
```

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->
NA


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced new entities for handling WebSocket and REST responses, including `ListenWSWord`, `ListenWSAlternative`, `ListenWSChannel`, and their REST counterparts.
	- Enhanced data representation for WebSocket responses, improving the handling of words, alternatives, and channels.

- **Bug Fixes**
	- Clarified the handling of `_asyncio_thread` in the `Microphone` class for better state management.

- **Refactor**
	- Streamlined import statements across various modules to focus on new listening functionalities, removing outdated entities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->