### PR TITLE
use clear_result in logs instead of undefined meta_result

### DIFF
--- a/deepgram/clients/speak/v1/websocket/async_client.py
+++ b/deepgram/clients/speak/v1/websocket/async_client.py
@@ -328,7 +328,7 @@ class AsyncSpeakWSClient(
                     )
                 case SpeakWebSocketEvents.Cleared:
                     clear_result: ClearedResponse = ClearedResponse.from_json(message)
-                    self._logger.verbose("ClearedResponse: %s", meta_result)
+                    self._logger.verbose("ClearedResponse: %s", clear_result)
                     await self._emit(
                         SpeakWebSocketEvents(SpeakWebSocketEvents.Cleared),
                         cleared=clear_result,

--- a/deepgram/clients/speak/v1/websocket/client.py
+++ b/deepgram/clients/speak/v1/websocket/client.py
@@ -326,7 +326,7 @@ class SpeakWSClient(
                     )
                 case SpeakWebSocketEvents.Cleared:
                     clear_result: ClearedResponse = ClearedResponse.from_json(message)
-                    self._logger.verbose("ClearedResponse: %s", meta_result)
+                    self._logger.verbose("ClearedResponse: %s", clear_result)
                     self._emit(
                         SpeakWebSocketEvents(SpeakWebSocketEvents.Cleared),
                         cleared=clear_result,


### PR DESCRIPTION
fixes #476 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected logging statement in the text processing for `ClearedResponse` to ensure accurate variable reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->