### PR TITLE
Fix for Deepgram async websocket

### DIFF
--- a/deepgram/clients/common/v1/abstract_async_websocket.py
+++ b/deepgram/clients/common/v1/abstract_async_websocket.py
@@ -136,7 +136,7 @@ class AbstractAsyncWebSocketClient(ABC):  # pylint: disable=too-many-instance-at
         try:
             self._socket = await websockets.connect(
                 url_with_params,
-                extra_headers=combined_headers,
+                additional_headers=combined_headers,
                 ping_interval=PING_INTERVAL,
             )
             self._exit_event.clear()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 httpx = "^0.25.2"
-websockets = "^12.0"
+websockets = "^14.1"
 typing-extensions = "^4.9.0"
 dataclasses-json = "^0.6.3"
 aiohttp = "^3.9.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # pip install -r requirements.txt
 
 # standard libs
-websockets==12.*
+websockets==14.*
 httpx==0.*
 dataclasses-json==0.*
 dataclasses==0.*

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "httpx>=0.25.2",
-        "websockets>=12.0",
+        "websockets>=14.0",
         "dataclasses-json>=0.6.3",
         "typing_extensions>=4.9.0",
         "aiohttp>=3.9.1",


### PR DESCRIPTION
## Proposed changes

The Python websockets library seems to accept `additional_headers` not `extra_headers`:
https://github.com/python-websockets/websockets/blob/main/src/websockets/asyncio/client.py#L79

Fixes deepgram/deepgram-python-sdk#483

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Transitioned the project configuration from Poetry to Setuptools for improved dependency management.
  
- **Bug Fixes**
	- Updated the `websockets` library version to ensure compatibility and access to new features.

- **Chores**
	- Made structural updates to the configuration files (`pyproject.toml`, `requirements.txt`, `setup.py`) to reflect the new dependency management approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->