### PR TITLE
pin the version of the websockets dependency to 12 or 13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "httpx>=0.25.2",
-        "websockets>=12.0",
+        "websockets>=12.0,<14.0",
         "dataclasses-json>=0.6.3",
         "typing_extensions>=4.9.0",
         "aiohttp>=3.9.1",


### PR DESCRIPTION
## Proposed changes

Users who install or upgrade this SDK are affected by #483. This PR pins the websocket dependency to v12 or v13, both of which are compatible with the current codebase.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments
