### PR TITLE
Add threading.Thread Class Override

### DIFF
--- a/deepgram/clients/common/v1/abstract_sync_websocket.py
+++ b/deepgram/clients/common/v1/abstract_sync_websocket.py
@@ -59,7 +59,12 @@ class AbstractSyncWebSocketClient(ABC):  # pylint: disable=too-many-instance-att
     _options: Optional[Dict] = None
     _headers: Optional[Dict] = None
 
-    def __init__(self, config: DeepgramClientOptions, endpoint: str = "", thread_cls: Type[threading.Thread] = threading.Thread) -> None:
+    def __init__(
+        self,
+        config: DeepgramClientOptions,
+        endpoint: str = "",
+        thread_cls: Type[threading.Thread] = threading.Thread,
+    ):
         if config is None:
             raise DeepgramError("Config is required")
         if endpoint == "":

--- a/deepgram/clients/common/v1/abstract_sync_websocket.py
+++ b/deepgram/clients/common/v1/abstract_sync_websocket.py
@@ -38,6 +38,12 @@ class AbstractSyncWebSocketClient(ABC):  # pylint: disable=too-many-instance-att
 
     This class provides methods to establish a WebSocket connection generically for
     use in all WebSocket clients.
+
+    Args:
+        config (DeepgramClientOptions): all the options for the client
+        endpoint (str): the endpoint to connect to
+        thread_cls (Type[threading.Thread]): optional thread class to use for creating threads,
+            defaults to threading.Thread. Useful for custom thread management like ContextVar support.
     """
 
     _logger: verboselogs.VerboseLogger

--- a/deepgram/clients/listen/v1/websocket/client.py
+++ b/deepgram/clients/listen/v1/websocket/client.py
@@ -92,7 +92,11 @@ class ListenWebSocketClient(
         }
 
         # call the parent constructor
-        super().__init__(self._config, self._endpoint)
+        super().__init__(
+            config=self._config,
+            endpoint=self._endpoint,
+            thread_cls=self._thread_cls,
+        )
 
     # pylint: disable=too-many-statements,too-many-branches
     def start(

--- a/deepgram/clients/listen/v1/websocket/client.py
+++ b/deepgram/clients/listen/v1/websocket/client.py
@@ -38,10 +38,12 @@ class ListenWebSocketClient(
     """
     Client for interacting with Deepgram's live transcription services over WebSockets.
 
-     This class provides methods to establish a WebSocket connection for live transcription and handle real-time transcription events.
+    This class provides methods to establish a WebSocket connection for live transcription and handle real-time transcription events.
 
-     Args:
-         config (DeepgramClientOptions): all the options for the client.
+    Args:
+        config (DeepgramClientOptions): all the options for the client.
+        thread_cls (Type[threading.Thread]): optional thread class to use for creating threads,
+        defaults to threading.Thread. Useful for custom thread management like ContextVar support.
     """
 
     _logger: verboselogs.VerboseLogger

--- a/deepgram/clients/listen/v1/websocket/client.py
+++ b/deepgram/clients/listen/v1/websocket/client.py
@@ -62,7 +62,11 @@ class ListenWebSocketClient(
     _options: Optional[Dict] = None
     _headers: Optional[Dict] = None
 
-    def __init__(self, config: DeepgramClientOptions, thread_cls: Type[threading.Thread] = threading.Thread):
+    def __init__(
+        self,
+        config: DeepgramClientOptions,
+        thread_cls: Type[threading.Thread] = threading.Thread,
+    ):
         if config is None:
             raise DeepgramError("Config is required")
 


### PR DESCRIPTION
## Proposed changes
This adds the ability to override the `threading.Thread` class used within `ListenWebSocketClient`.

By default, the standard Python `threading.Thread` class will be used. There is an option to specify an override which sub-classes `threading.Thread`.

Custom thread classes may be used for session management and logging, such as when using `ContextVar`. 
## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a customizable threading option for the WebSocket client, allowing users to specify a custom thread class.
- **Bug Fixes**
	- Improved thread management for keep-alive and flush operations without altering existing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->