### PR TITLE
Correct typo in comments

### DIFF
--- a/examples/speech-to-text/websocket/async_microphone/main.py
+++ b/examples/speech-to-text/websocket/async_microphone/main.py
@@ -58,7 +58,7 @@ async def main():
                 # See docs: https://developers.deepgram.com/docs/understand-endpointing-interim-results
                 is_finals.append(sentence)
 
-                # Speech Final means we have detected sufficent silence to consider this end of speech
+                # Speech Final means we have detected sufficient silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
                     utterance = " ".join(is_finals)

--- a/examples/speech-to-text/websocket/microphone/main.py
+++ b/examples/speech-to-text/websocket/microphone/main.py
@@ -48,7 +48,7 @@ def main():
                 # See docs: https://developers.deepgram.com/docs/understand-endpointing-interim-results
                 is_finals.append(sentence)
 
-                # Speech Final means we have detected sufficent silence to consider this end of speech
+                # Speech Final means we have detected sufficient silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
                     utterance = " ".join(is_finals)

--- a/tests/edge_cases/auto_flush/async_microphone_mute/main.py
+++ b/tests/edge_cases/auto_flush/async_microphone_mute/main.py
@@ -59,7 +59,7 @@ async def main():
                 # See docs: https://developers.deepgram.com/docs/understand-endpointing-interim-results
                 is_finals.append(sentence)
 
-                # Speech Final means we have detected sufficent silence to consider this end of speech
+                # Speech Final means we have detected sufficient silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
                     utterance = " ".join(is_finals)

--- a/tests/edge_cases/auto_flush/microphone_mute/main.py
+++ b/tests/edge_cases/auto_flush/microphone_mute/main.py
@@ -46,7 +46,7 @@ def main():
                 # See docs: https://developers.deepgram.com/docs/understand-endpointing-interim-results
                 is_finals.append(sentence)
 
-                # Speech Final means we have detected sufficent silence to consider this end of speech
+                # Speech Final means we have detected sufficient silence to consider this end of speech
                 # Speech final is the lowest latency result as it triggers as soon an the endpointing value has triggered
                 if result.speech_final:
                     utterance = " ".join(is_finals)


### PR DESCRIPTION

sufficent -> sufficient :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "sufficient" in comments across multiple Python files related to speech-to-text functionality.
	- No functional changes were made to the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->