### PR TITLE
Fix support for Python WebSocket >=14 while preserving backward compatibility

### DIFF
--- a/deepgram/clients/common/v1/abstract_sync_websocket.py
+++ b/deepgram/clients/common/v1/abstract_sync_websocket.py
@@ -184,7 +184,7 @@ class AbstractSyncWebSocketClient(ABC):  # pylint: disable=too-many-instance-att
             self._logger.notice("start succeeded")
             self._logger.debug("AbstractSyncWebSocketClient.start LEAVE")
             return True
-        except websockets.ConnectionClosed as e:
+        except websockets.exceptions.ConnectionClosed as e:
             self._logger.error(
                 "ConnectionClosed in AbstractSyncWebSocketClient.start: %s", e
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.10"
 httpx = "^0.25.2"
-websockets = "^12.0"
+websockets = ">=12.0"
 typing-extensions = "^4.9.0"
 dataclasses-json = "^0.6.3"
 aiohttp = "^3.9.1"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # pip install -r requirements.txt
 
 # standard libs
-websockets==12.*
+websockets>=12.0
 httpx==0.*
 dataclasses-json==0.*
 dataclasses==0.*

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     packages=find_packages(exclude=["tests"]),
     install_requires=[
         "httpx>=0.25.2",
-        "websockets>=12.0,<14.0",
+        "websockets>=12.0",
         "dataclasses-json>=0.6.3",
         "typing_extensions>=4.9.0",
         "aiohttp>=3.9.1",


### PR DESCRIPTION
## Proposed changes
Websockets did a breaking change with version 14:
The client async base implementation changed and the "extra_headers" parameter was renamed to "additional_headers". 
(See issue #483)
A previous change solved the issue by pinning the websockets version to 12 or 13 (https://github.com/deepgram/deepgram-python-sdk/pull/487).

An alternative solution was proposed with the PR #486 but it was not satisfying as it was breaking the backward compatibility.

The purpose of the current PR is to support the new versions of python websockets by preserving support for the older 12 and 13 versions.

Fixes #483

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Dependencies**
	- Updated `websockets` library version constraint to allow versions 12.0 and higher across multiple configuration files.

- **Compatibility**
	- Enhanced handling of WebSocket connections to support different versions of the `websockets` library.
	- Improved exception handling for closed connections to ensure robustness in the WebSocket client implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->