### PR TITLE
Correctly handled response headers in speak rest client for aura 2

### DIFF
--- a/deepgram/clients/speak/v1/rest/client.py
+++ b/deepgram/clients/speak/v1/rest/client.py
@@ -160,15 +160,28 @@ class SpeakRESTClient(AbstractSyncRestClient):
         self._logger.info("addons: %s", addons)
         self._logger.info("headers: %s", headers)
 
-        return_vals = [
-            "content-type",
-            "request-id",
-            "model-uuid",
-            "model-name",
-            "char-count",
-            "transfer-encoding",
-            "date",
-        ]
+        is_aura_2_model = options["model"].split("-")[1] == "2"
+
+        if is_aura_2_model:
+            return_vals = [
+                "content-type",
+                "request-id",
+                "model-name",
+                "characters",
+                "transfer-encoding",
+                "date",
+            ]
+        else:
+            return_vals = [
+                "content-type",
+                "request-id",
+                "model-uuid",
+                "model-name",
+                "char-count",
+                "transfer-encoding",
+                "date",
+            ]
+
         result = self.post_memory(
             url,
             options=options,
@@ -181,17 +194,31 @@ class SpeakRESTClient(AbstractSyncRestClient):
         )
 
         self._logger.info("result: %s", result)
-        resp = SpeakRESTResponse(
-            content_type=str(result["content-type"]),
-            request_id=str(result["request-id"]),
-            model_uuid=str(result["model-uuid"]),
-            model_name=str(result["model-name"]),
-            characters=int(str(result["char-count"])),
-            transfer_encoding=str(result["transfer-encoding"]),
-            date=str(result["date"]),
-            stream=cast(io.BytesIO, result["stream"]),
-            stream_memory=cast(io.BytesIO, result["stream"]),
-        )
+
+        if is_aura_2_model:
+            resp = SpeakRESTResponse(
+                content_type=str(result["content-type"]),
+                request_id=str(result["request-id"]),
+                model_name=str(result["model-name"]),
+                characters=int(str(result["characters"])),
+                transfer_encoding=str(result["transfer-encoding"]),
+                date=str(result["date"]),
+                stream=cast(io.BytesIO, result["stream"]),
+                stream_memory=cast(io.BytesIO, result["stream"]),
+            )
+        else:
+            resp = SpeakRESTResponse(
+                content_type=str(result["content-type"]),
+                request_id=str(result["request-id"]),
+                model_uuid=str(result["model-uuid"]),
+                model_name=str(result["model-name"]),
+                characters=int(str(result["char-count"])),
+                transfer_encoding=str(result["transfer-encoding"]),
+                date=str(result["date"]),
+                stream=cast(io.BytesIO, result["stream"]),
+                stream_memory=cast(io.BytesIO, result["stream"]),
+            )
+
         self._logger.verbose("resp Object: %s", resp)
         self._logger.notice("speak succeeded")
         self._logger.debug("SpeakClient.stream LEAVE")


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->
There was a bug raised in this discord thread:
https://discord.com/channels/1108042150941294664/1361735544278745359

Essentially the POST response from aura 2 for TTS does not return the same headers as aura 2 and the python sdk previously did not handle the aura 2 headers correctly.


## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

