### PR TITLE
Handle absence of model-uuid field in early Aura-2

### DIFF
--- a/deepgram/clients/speak/v1/rest/client.py
+++ b/deepgram/clients/speak/v1/rest/client.py
@@ -166,7 +166,6 @@ class SpeakRESTClient(AbstractSyncRestClient):
             "model-uuid",
             "model-name",
             "char-count",
-            "characters", # Initial Aura-2 variation of char-count
             "transfer-encoding",
             "date",
         ]
@@ -182,13 +181,12 @@ class SpeakRESTClient(AbstractSyncRestClient):
         )
 
         self._logger.info("result: %s", result)
-
         resp = SpeakRESTResponse(
             content_type=str(result["content-type"]),
             request_id=str(result["request-id"]),
             model_uuid=str(result.get("model-uuid", "")),
             model_name=str(result["model-name"]),
-            characters=int(str(result.get("char-count") or result.get("characters"))),
+            characters=int(str(result["char-count"])),
             transfer_encoding=str(result["transfer-encoding"]),
             date=str(result["date"]),
             stream=cast(io.BytesIO, result["stream"]),

--- a/deepgram/clients/speak/v1/rest/client.py
+++ b/deepgram/clients/speak/v1/rest/client.py
@@ -166,6 +166,7 @@ class SpeakRESTClient(AbstractSyncRestClient):
             "model-uuid",
             "model-name",
             "char-count",
+            "characters", # Initial Aura-2 variation of char-count
             "transfer-encoding",
             "date",
         ]
@@ -181,12 +182,13 @@ class SpeakRESTClient(AbstractSyncRestClient):
         )
 
         self._logger.info("result: %s", result)
+
         resp = SpeakRESTResponse(
             content_type=str(result["content-type"]),
             request_id=str(result["request-id"]),
-            model_uuid=str(result["model-uuid"]),
+            model_uuid=str(result.get("model-uuid", "")),
             model_name=str(result["model-name"]),
-            characters=int(str(result["char-count"])),
+            characters=int(str(result.get("char-count") or result.get("characters"))),
             transfer_encoding=str(result["transfer-encoding"]),
             date=str(result["date"]),
             stream=cast(io.BytesIO, result["stream"]),


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->


## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [x] I have lint'ed all of my code using repo standards
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->

__Test Plan__

1. Set up virtual environment and installed the local SDK:
```
python3 -m venv venv
source venv/bin/activate
pip install -e .
pip install dotenv
```

2. Ran the TTS script that customers are using: https://github.com/deepgram/deepgram-python-sdk/blob/main/examples/text-to-speech/rest/file/hello_world/main.py

a. With `model=aura-asteria-en`:

```
(venv) (base) deepgram-python-sdk % python3 ~/Downloads/aura-tts.py
Version.v ENTER
version: 1
path: deepgram.clients.speak.v1.rest.client
class_name: SpeakRESTClient
Version.v succeeded
Version.v LEAVE
SpeakClient.save ENTER
SpeakClient.stream ENTER
url: https://api.deepgram.com/v1/speak
source: {'text': 'Working as expected!'}
SpeakRESTOptions switching class -> dict
options: {'model': 'aura-asteria-en'}
addons: None
headers: None
result: {'content-type': 'audio/mpeg', 'request-id': '50a224fa-1f78-409a-9ad3-33a3646df727', 'model-uuid': 'ecb76e9d-f2db-4127-8060-79b05590d22f', 'model-name': 'aura-asteria-en', 'char-count': '20', 'transfer-encoding': 'chunked', 'date': 'Wed, 16 Apr 2025 14:32:43 GMT', 'stream': <_io.BytesIO object at 0x102c00450>}
resp Object: {
    "content_type": "audio/mpeg",
    "request_id": "50a224fa-1f78-409a-9ad3-33a3646df727",
    "model_uuid": "ecb76e9d-f2db-4127-8060-79b05590d22f",
    "model_name": "aura-asteria-en",
    "characters": 20,
    "transfer_encoding": "chunked",
    "date": "Wed, 16 Apr 2025 14:32:43 GMT"
}
speak succeeded
SpeakClient.stream LEAVE
SpeakClient.save LEAVE
{
    "content_type": "audio/mpeg",
    "request_id": "50a224fa-1f78-409a-9ad3-33a3646df727",
    "model_uuid": "ecb76e9d-f2db-4127-8060-79b05590d22f",
    "model_name": "aura-asteria-en",
    "characters": 20,
    "transfer_encoding": "chunked",
    "date": "Wed, 16 Apr 2025 14:32:43 GMT",
    "filename": "aura1-april16.mp3"
}
```

b. With `model=aura-2-asteria-en`:

```
(venv) (base) deepgram-python-sdk % python3 ~/Downloads/aura-tts.py
Version.v ENTER
version: 1
path: deepgram.clients.speak.v1.rest.client
class_name: SpeakRESTClient
Version.v succeeded
Version.v LEAVE
SpeakClient.save ENTER
SpeakClient.stream ENTER
url: https://api.deepgram.com/v1/speak
source: {'text': 'Working as expected!'}
SpeakRESTOptions switching class -> dict
options: {'model': 'aura-2-asteria-en'}
addons: None
headers: None
result: {'content-type': 'audio/mpeg', 'request-id': '1a47b981-80b9-44d5-9df3-893708476d27', 'model-name': 'aura-2-asteria-en', 'char-count': '20', 'transfer-encoding': 'chunked', 'date': 'Wed, 16 Apr 2025 14:32:50 GMT', 'stream': <_io.BytesIO object at 0x105b00360>}
resp Object: {
    "content_type": "audio/mpeg",
    "request_id": "1a47b981-80b9-44d5-9df3-893708476d27",
    "model_uuid": "",
    "model_name": "aura-2-asteria-en",
    "characters": 20,
    "transfer_encoding": "chunked",
    "date": "Wed, 16 Apr 2025 14:32:50 GMT"
}
speak succeeded
SpeakClient.stream LEAVE
SpeakClient.save LEAVE
{
    "content_type": "audio/mpeg",
    "request_id": "1a47b981-80b9-44d5-9df3-893708476d27",
    "model_uuid": "",
    "model_name": "aura-2-asteria-en",
    "characters": 20,
    "transfer_encoding": "chunked",
    "date": "Wed, 16 Apr 2025 14:32:50 GMT",
    "filename": "aura2-april16.mp3"
}
```

3. Listened to the two audio output files and confirmed that both are valid audio, with Aura-2 clearly working and higher quality than Aura-1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved stability by preventing errors when certain response fields are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->