### PR TITLE
fix: correct the language property location and type

### DIFF
--- a/deepgram/clients/agent/v1/websocket/options.py
+++ b/deepgram/clients/agent/v1/websocket/options.py
@@ -363,6 +363,7 @@ class SettingsOptions(BaseResponse):
     type: str = str(AgentWebSocketEvents.Settings)
     audio: Audio = field(default_factory=Audio)
     agent: Agent = field(default_factory=Agent)
+    language: Language = field(default_factory=Language)
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -370,6 +371,8 @@ class SettingsOptions(BaseResponse):
             _dict["audio"] = Audio.from_dict(_dict["audio"])
         if "agent" in _dict and isinstance(_dict["agent"], dict):
             _dict["agent"] = Agent.from_dict(_dict["agent"])
+        if "language" in _dict and isinstance(_dict["language"], dict):
+            _dict["language"] = Language.from_dict(_dict["language"])
         return _dict[key]
 
     def check(self):

--- a/deepgram/clients/agent/v1/websocket/options.py
+++ b/deepgram/clients/agent/v1/websocket/options.py
@@ -212,6 +212,13 @@ class SpeakProvider(BaseResponse):
             _dict["voice"] = CartesiaVoice.from_dict(_dict["voice"])
         return _dict[key]
 
+@dataclass
+class Language(BaseResponse):
+    """
+    Define the language for the agent.
+    """
+
+    type: str = field(default="en")
 
 @dataclass
 class Think(BaseResponse):
@@ -284,6 +291,7 @@ class Agent(BaseResponse):
     This class defines any configuration settings for the Agent model.
     """
 
+    language: Language = field(default_factory=Language)
     listen: Listen = field(default_factory=Listen)
     think: Think = field(default_factory=Think)
     speak: Speak = field(default_factory=Speak)
@@ -293,6 +301,8 @@ class Agent(BaseResponse):
 
     def __getitem__(self, key):
         _dict = self.to_dict()
+        if "language" in _dict and isinstance(_dict["language"], dict):
+            _dict["language"] = Language.from_dict(_dict["language"])
         if "listen" in _dict and isinstance(_dict["listen"], dict):
             _dict["listen"] = Listen.from_dict(_dict["listen"])
         if "think" in _dict and isinstance(_dict["think"], dict):
@@ -300,8 +310,6 @@ class Agent(BaseResponse):
         if "speak" in _dict and isinstance(_dict["speak"], dict):
             _dict["speak"] = Speak.from_dict(_dict["speak"])
         return _dict[key]
-
-
 @dataclass
 class Input(BaseResponse):
     """
@@ -343,16 +351,6 @@ class Audio(BaseResponse):
             _dict["output"] = Output.from_dict(_dict["output"])
         return _dict[key]
 
-
-@dataclass
-class Language(BaseResponse):
-    """
-    Define the language for the agent.
-    """
-
-    type: str = field(default="en")
-
-
 @dataclass
 class SettingsOptions(BaseResponse):
     """
@@ -363,7 +361,6 @@ class SettingsOptions(BaseResponse):
     type: str = str(AgentWebSocketEvents.Settings)
     audio: Audio = field(default_factory=Audio)
     agent: Agent = field(default_factory=Agent)
-    language: Language = field(default_factory=Language)
 
     def __getitem__(self, key):
         _dict = self.to_dict()
@@ -371,9 +368,6 @@ class SettingsOptions(BaseResponse):
             _dict["audio"] = Audio.from_dict(_dict["audio"])
         if "agent" in _dict and isinstance(_dict["agent"], dict):
             _dict["agent"] = Agent.from_dict(_dict["agent"])
-        if "language" in _dict and isinstance(_dict["language"], dict):
-            _dict["language"] = Language.from_dict(_dict["language"])
-        return _dict[key]
 
     def check(self):
         """

--- a/deepgram/clients/agent/v1/websocket/options.py
+++ b/deepgram/clients/agent/v1/websocket/options.py
@@ -291,7 +291,7 @@ class Agent(BaseResponse):
     This class defines any configuration settings for the Agent model.
     """
 
-    language: Language = field(default_factory=Language)
+    language: str = field(default="en")
     listen: Listen = field(default_factory=Listen)
     think: Think = field(default_factory=Think)
     speak: Speak = field(default_factory=Speak)

--- a/deepgram/clients/agent/v1/websocket/options.py
+++ b/deepgram/clients/agent/v1/websocket/options.py
@@ -211,15 +211,6 @@ class SpeakProvider(BaseResponse):
         if "voice" in _dict and isinstance(_dict["voice"], dict):
             _dict["voice"] = CartesiaVoice.from_dict(_dict["voice"])
         return _dict[key]
-
-@dataclass
-class Language(BaseResponse):
-    """
-    Define the language for the agent.
-    """
-
-    type: str = field(default="en")
-
 @dataclass
 class Think(BaseResponse):
     """
@@ -301,8 +292,6 @@ class Agent(BaseResponse):
 
     def __getitem__(self, key):
         _dict = self.to_dict()
-        if "language" in _dict and isinstance(_dict["language"], dict):
-            _dict["language"] = Language.from_dict(_dict["language"])
         if "listen" in _dict and isinstance(_dict["listen"], dict):
             _dict["listen"] = Listen.from_dict(_dict["listen"])
         if "think" in _dict and isinstance(_dict["think"], dict):

--- a/examples/agent/async_simple/main.py
+++ b/examples/agent/async_simple/main.py
@@ -114,7 +114,7 @@ async def main():
         options.agent.listen.provider.keyterms = ["hello", "goodbye"]
         options.agent.listen.provider.model = "nova-3"
         options.agent.listen.provider.type = "deepgram"
-        options.language = "en"
+        options.agent.language = "en"
 
 
         print("\n\nPress Enter to stop...\n\n")

--- a/examples/agent/no_mic/main.py
+++ b/examples/agent/no_mic/main.py
@@ -51,9 +51,9 @@ def main():
         # Agent configuration
         options.agent.language = "en"
         options.agent.listen.provider.type = "deepgram"
-        options.agent.listen.model = "nova-3"
+        options.agent.listen.provider.model = "nova-3"
         options.agent.think.provider.type = "open_ai"
-        options.agent.think.model = "gpt-4o-mini"
+        options.agent.think.provider.model = "gpt-4o-mini"
         options.agent.think.prompt = "You are a friendly AI assistant."
         options.agent.speak.provider.type = "deepgram"
         options.agent.speak.model = "aura-2-thalia-en"

--- a/examples/agent/simple/main.py
+++ b/examples/agent/simple/main.py
@@ -138,7 +138,7 @@ def main():
         options.agent.listen.provider.keyterms = ["hello", "goodbye"]
         options.agent.listen.provider.model = "nova-3"
         options.agent.listen.provider.type = "deepgram"
-        options.language = "en"
+        options.agent.language = "en"
         if dg_connection.start(options) is False:
             print("Failed to start connection")
             return


### PR DESCRIPTION
## Proposed changes

Relates to the bug reported in [The community ](https://github.com/orgs/deepgram/discussions/1067#discussioncomment-13326127)

Let me analyze what I found:

The Language class is defined in options.py but it's not being used in any of the main client classes or settings. It appears to be defined but not integrated into the actual SDK functionality.

Looking at the SettingsOptions class which is the main configuration class used when starting a websocket connection, it doesn't include the Language class as a field.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update or tests (if none of the other choices apply)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210418536779480

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a language option in the agent configuration.
- **Bug Fixes**
  - Corrected language and model property assignments in example configurations for better clarity and structure.
- **Chores**
  - Simplified language field type in agent settings and cleaned up redundant code formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->