### PR TITLE
fix:  Logging - Downgrade 'tasks cancelled error' to debug-level logline

### DIFF
--- a/deepgram/clients/agent/v1/websocket/async_client.py
+++ b/deepgram/clients/agent/v1/websocket/async_client.py
@@ -700,7 +700,7 @@ class AsyncAgentWebSocketClient(
             return True
 
         except asyncio.CancelledError as e:
-            self._logger.error("tasks cancelled error: %s", e)
+            self._logger.debug("tasks cancelled error: %s", e)
             self._logger.debug("AsyncAgentWebSocketClient.finish LEAVE")
             return False
 

--- a/deepgram/clients/common/v1/abstract_async_websocket.py
+++ b/deepgram/clients/common/v1/abstract_async_websocket.py
@@ -488,7 +488,7 @@ class AbstractAsyncWebSocketClient(ABC):  # pylint: disable=too-many-instance-at
             return True
 
         except asyncio.CancelledError as e:
-            self._logger.error("tasks cancelled error: %s", e)
+            self._logger.debug("tasks cancelled error: %s", e)
             self._logger.debug("AbstractAsyncWebSocketClient.finish LEAVE")
             return True
 

--- a/deepgram/clients/listen/v1/websocket/async_client.py
+++ b/deepgram/clients/listen/v1/websocket/async_client.py
@@ -555,7 +555,7 @@ class AsyncListenWebSocketClient(
             return True
 
         except asyncio.CancelledError as e:
-            self._logger.error("tasks cancelled error: %s", e)
+            self._logger.debug("tasks cancelled error: %s", e)
             self._logger.debug("AsyncListenWebSocketClient.finish LEAVE")
             return False
 


### PR DESCRIPTION
## Proposed changes
<!--
Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue.
-->

Downgrade `tasks cancelled error` log line to debug-level.

Mitigates an issue reported by several customers: https://github.com/deepgram/deepgram-python-sdk/issues/501

That log line isn't really needed at error-level because it will always be raised when cancelling tasks.

## Types of changes

What types of changes does your code introduce to the community Python SDK?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update or tests (if none of the other choices apply) - logging change

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] I have lint'ed all of my code using repo standards
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments
<!--
If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc...
-->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted logging behavior for cancellation errors to reduce unnecessary error messages. These events now appear at the debug level instead of the error level.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->