### PR TITLE
add support for mip opt out in TTS

### DIFF
--- a/deepgram/clients/speak/v1/rest/options.py
+++ b/deepgram/clients/speak/v1/rest/options.py
@@ -38,6 +38,9 @@ class SpeakRESTOptions(BaseResponse):
     bit_rate: Optional[int] = field(
         default=None, metadata=dataclass_config(exclude=lambda f: f is None)
     )
+    mip_opt_out: Optional[bool] = field(
+        default=None, metadata=dataclass_config(exclude=lambda f: f is None)
+    )
 
     def check(self):
         """


### PR DESCRIPTION
Add support for mip out accounts and deepgram TTS

Related issue
https://github.com/deepgram/deepgram-python-sdk/issues/565

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an optional setting to opt out of MIP in the speech options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->