### PR TITLE
fix: redact Authorization header from websockets DEBUG logs

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -9,6 +9,11 @@
 # This file is manually maintained and should not be regenerated
 src/deepgram/client.py
 
+# Hand-written security utility: installs a logging.Filter on the third-party
+# `websockets` client/server loggers that masks the Authorization header (API
+# key / access token) in DEBUG handshake logs. No Fern-generated counterpart.
+src/deepgram/_secure_logging.py
+
 # WebSocket socket clients:
 # - except Exception broad catch (supports custom transports, generator narrows to WebSocketException)
 # - _sanitize_numeric_types in agent socket client (float→int for API)
@@ -92,6 +97,7 @@ src/deepgram/core/query_encoder.py
 tests/custom/test_agent_history.py
 tests/custom/test_compat_aliases.py
 tests/custom/test_query_encoder.py
+tests/custom/test_secure_logging.py
 tests/custom/test_text_builder.py
 tests/custom/test_transport.py
 tests/typecheck/compat_aliases.py

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ How to identify:
 
 Current permanently frozen files:
 - `src/deepgram/client.py` — entirely custom (Bearer auth, session ID, `transport_factory`, `reconnect` parity flag); no Fern equivalent
+- `src/deepgram/_secure_logging.py` — hand-written security utility that installs a `logging.Filter` on the `websockets` client/server loggers to mask the `Authorization` header in DEBUG handshake logs; called from `client.py`; no Fern equivalent
 - `src/deepgram/helpers/` — hand-written TextBuilder helpers
 - `src/deepgram/agent/v1/types/agent_v1history_content.py`, `src/deepgram/agent/v1/types/agent_v1history_function_calls.py`, `src/deepgram/agent/v1/types/agent_v1settings_agent_context_messages_item.py`, `src/deepgram/agent/v1/types/agent_v1settings_agent_context_messages_item_content.py`, `src/deepgram/agent/v1/types/agent_v1settings_agent_context_messages_item_content_role.py`, `src/deepgram/agent/v1/types/agent_v1settings_agent_context_messages_item_function_calls.py`, `src/deepgram/agent/v1/types/agent_v1settings_agent_context_messages_item_function_calls_function_calls_item.py` — hand-written compatibility aliases preserving old public Agent History type imports after regen renames
 - `src/deepgram/agent/v1/requests/agent_v1history_content.py`, `src/deepgram/agent/v1/requests/agent_v1history_function_calls.py`, `src/deepgram/agent/v1/requests/agent_v1settings_agent_context_messages_item.py`, `src/deepgram/agent/v1/requests/agent_v1settings_agent_context_messages_item_content.py`, `src/deepgram/agent/v1/requests/agent_v1settings_agent_context_messages_item_function_calls.py`, `src/deepgram/agent/v1/requests/agent_v1settings_agent_context_messages_item_function_calls_function_calls_item.py` — hand-written compatibility aliases preserving old public Agent History request-param imports after regen renames
@@ -32,6 +33,7 @@ Current permanently frozen files:
 - `tests/custom/test_agent_history.py` — hand-written regression test for Agent History websocket payload parsing
 - `tests/custom/test_compat_aliases.py` — hand-written regression test for backward-compatible alias imports after regen renames
 - `tests/custom/test_query_encoder.py` — hand-written regression test that `core/query_encoder.py` coerces Python bools to lowercase `"true"`/`"false"` before `urlencode` so websocket query strings stay wire-correct
+- `tests/custom/test_secure_logging.py` — hand-written regression test that the `websockets` Authorization-header DEBUG logs are redacted (API key never logged in clear text)
 - `tests/custom/test_text_builder.py`, `tests/custom/test_transport.py` — hand-written tests
 - `tests/typecheck/compat_aliases.py` — hand-written mypy `assert_type` coverage for backward-compatible alias TypedDicts
 - `tests/manual/` — manual standalone tests

--- a/src/deepgram/_secure_logging.py
+++ b/src/deepgram/_secure_logging.py
@@ -1,0 +1,95 @@
+"""Redaction of credentials from third-party ``websockets`` debug logs.
+
+The ``websockets`` library logs the full opening handshake at ``DEBUG`` level,
+one record per header, via ``logger.debug("> %s: %s", name, value)`` (and
+``"< %s: %s"`` for the response). That includes the ``Authorization`` header —
+i.e. the Deepgram API key or access token in clear text. Any application that
+enables ``DEBUG`` logging (common during development/troubleshooting) would then
+write the credential into its logs, from where it is easily committed to a repo
+or shipped to a log aggregator.
+
+This module installs a :class:`logging.Filter` on the ``websockets`` client and
+server loggers that masks the value of sensitive headers *before* the record
+reaches any handler/formatter, so the credential is never emitted regardless of
+the application's log level. The filter only rewrites the value of known
+credential headers; it suppresses nothing and changes no other output.
+
+This is a hand-written security utility with no Fern-generated counterpart and
+is frozen in ``.fernignore``.
+"""
+
+import logging
+import typing
+
+# Header names (lower-cased) whose values must never be logged in clear text.
+_SENSITIVE_HEADERS = frozenset({"authorization", "proxy-authorization"})
+
+# Replacement for the credential portion of a sensitive header value.
+_REDACTED = "[REDACTED]"
+
+# websockets >= 12 emits handshake header records directly on these loggers
+# (no per-connection child loggers), so a filter attached here sees every
+# header record before it propagates to the application's handlers.
+_TARGET_LOGGERS = ("websockets.client", "websockets.server")
+
+
+def _mask_value(value: typing.Any) -> str:
+    """Mask a credential while preserving the auth scheme for debuggability.
+
+    ``"Token abc123"`` -> ``"Token [REDACTED]"`` and ``"bearer xyz"`` ->
+    ``"bearer [REDACTED]"``. A value with no scheme prefix is fully masked.
+    """
+    text = str(value)
+    scheme, sep, _ = text.partition(" ")
+    if sep and scheme:
+        return f"{scheme} {_REDACTED}"
+    return _REDACTED
+
+
+class RedactCredentialsFilter(logging.Filter):
+    """Masks sensitive header values in ``websockets`` handshake debug records.
+
+    websockets logs each handshake header as ``logger.debug("> %s: %s", name,
+    value)``. We rewrite ``record.args`` in place when the header name is a known
+    credential header, so the secret never reaches a handler or formatter. The
+    record is mutated before propagation, so every downstream handler sees the
+    redacted value. The filter always returns ``True`` (it never drops records).
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        msg = record.msg
+        args = record.args
+        if (
+            isinstance(msg, str)
+            and "%s: %s" in msg
+            and isinstance(args, tuple)
+            and len(args) == 2
+        ):
+            name, value = args
+            if isinstance(name, str) and name.lower() in _SENSITIVE_HEADERS:
+                record.args = (name, _mask_value(value))
+        return True
+
+
+def install_websocket_log_redaction() -> None:
+    """Attach :class:`RedactCredentialsFilter` to the websockets loggers.
+
+    Idempotent: a logger never accumulates more than one redaction filter, so it
+    is safe to call from every client constructor.
+    """
+    for name in _TARGET_LOGGERS:
+        logger = logging.getLogger(name)
+        if not any(isinstance(f, RedactCredentialsFilter) for f in logger.filters):
+            logger.addFilter(RedactCredentialsFilter())
+
+
+def uninstall_websocket_log_redaction() -> None:
+    """Remove the redaction filter from the websockets loggers.
+
+    Provided as an opt-out for applications that manage credential redaction
+    themselves and want the raw websockets debug output back.
+    """
+    for name in _TARGET_LOGGERS:
+        logger = logging.getLogger(name)
+        for f in [f for f in logger.filters if isinstance(f, RedactCredentialsFilter)]:
+            logger.removeFilter(f)

--- a/src/deepgram/client.py
+++ b/src/deepgram/client.py
@@ -26,6 +26,7 @@ import types
 import uuid
 from typing import Any, Callable, Dict, Optional
 
+from ._secure_logging import install_websocket_log_redaction
 from .base_client import AsyncBaseClient, BaseClient
 from .transport import install_transport
 
@@ -71,6 +72,9 @@ class DeepgramClient(BaseClient):
                     retry/reconnect lifecycle. The Python SDK has no wrapper reconnect layer
                     today, so this flag is declarative only -- it documents intent and is
                     reserved for any future SDK-side reconnect logic.
+    - `redact_credentials_in_logs`: Mask the `Authorization` header (API key / access token)
+                    in the `websockets` library's DEBUG handshake logs. Defaults to `True`; set
+                    to `False` to opt out and manage credential redaction yourself.
     - `telemetry_opt_out`: Telemetry opt-out flag (maintained for backwards compatibility, no-op).
     - `telemetry_handler`: Telemetry handler (maintained for backwards compatibility, no-op).
     """
@@ -80,8 +84,16 @@ class DeepgramClient(BaseClient):
         session_id: Optional[str] = kwargs.pop("session_id", None)
         transport_factory: Optional[Callable] = kwargs.pop("transport_factory", None)
         reconnect: bool = bool(kwargs.pop("reconnect", True))
+        redact_credentials_in_logs: bool = bool(kwargs.pop("redact_credentials_in_logs", True))
         telemetry_opt_out: bool = bool(kwargs.pop("telemetry_opt_out", True))
         telemetry_handler: Optional[Any] = kwargs.pop("telemetry_handler", None)
+
+        # Mask the Authorization header (API key / access token) in the
+        # third-party `websockets` library's DEBUG handshake logs so the
+        # credential is never written to application logs. On by default;
+        # pass `redact_credentials_in_logs=False` to manage redaction yourself.
+        if redact_credentials_in_logs:
+            install_websocket_log_redaction()
 
         # Use provided session_id or generate one
         final_session_id = session_id if session_id is not None else str(uuid.uuid4())
@@ -139,6 +151,9 @@ class AsyncDeepgramClient(AsyncBaseClient):
                     retry/reconnect lifecycle. The Python SDK has no wrapper reconnect layer
                     today, so this flag is declarative only -- it documents intent and is
                     reserved for any future SDK-side reconnect logic.
+    - `redact_credentials_in_logs`: Mask the `Authorization` header (API key / access token)
+                    in the `websockets` library's DEBUG handshake logs. Defaults to `True`; set
+                    to `False` to opt out and manage credential redaction yourself.
     - `telemetry_opt_out`: Telemetry opt-out flag (maintained for backwards compatibility, no-op).
     - `telemetry_handler`: Telemetry handler (maintained for backwards compatibility, no-op).
     """
@@ -148,8 +163,16 @@ class AsyncDeepgramClient(AsyncBaseClient):
         session_id: Optional[str] = kwargs.pop("session_id", None)
         transport_factory: Optional[Callable] = kwargs.pop("transport_factory", None)
         reconnect: bool = bool(kwargs.pop("reconnect", True))
+        redact_credentials_in_logs: bool = bool(kwargs.pop("redact_credentials_in_logs", True))
         telemetry_opt_out: bool = bool(kwargs.pop("telemetry_opt_out", True))
         telemetry_handler: Optional[Any] = kwargs.pop("telemetry_handler", None)
+
+        # Mask the Authorization header (API key / access token) in the
+        # third-party `websockets` library's DEBUG handshake logs so the
+        # credential is never written to application logs. On by default;
+        # pass `redact_credentials_in_logs=False` to manage redaction yourself.
+        if redact_credentials_in_logs:
+            install_websocket_log_redaction()
 
         # Use provided session_id or generate one
         final_session_id = session_id if session_id is not None else str(uuid.uuid4())

--- a/tests/custom/test_secure_logging.py
+++ b/tests/custom/test_secure_logging.py
@@ -1,0 +1,125 @@
+"""Tests for credential redaction in third-party ``websockets`` debug logs.
+
+Regression coverage for the security report that the SDK leaked the API key /
+access token into application logs: ``websockets`` logs the opening handshake at
+DEBUG, including ``Authorization: Token <key>``. The SDK installs a redaction
+filter on the websockets loggers so the credential is masked regardless of the
+application's log level.
+"""
+
+import logging
+
+import pytest
+
+from deepgram._secure_logging import (
+    RedactCredentialsFilter,
+    _mask_value,
+    install_websocket_log_redaction,
+    uninstall_websocket_log_redaction,
+)
+
+_WS_LOGGERS = ("websockets.client", "websockets.server")
+
+
+@pytest.fixture(autouse=True)
+def _clean_filters():
+    """Ensure each test starts and ends with no redaction filter installed."""
+    uninstall_websocket_log_redaction()
+    yield
+    uninstall_websocket_log_redaction()
+
+
+def _emit_header(caplog, logger_name, name, value):
+    """Emit a record exactly like websockets' handshake header logging."""
+    logger = logging.getLogger(logger_name)
+    with caplog.at_level(logging.DEBUG, logger=logger_name):
+        # websockets/client.py: self.logger.debug("> %s: %s", key, value)
+        logger.debug("> %s: %s", name, value)
+    return caplog.records[-1].getMessage()
+
+
+def test_authorization_token_is_redacted(caplog):
+    install_websocket_log_redaction()
+    msg = _emit_header(caplog, "websockets.client", "Authorization", "Token 3f10254bSECRETKEY")
+    assert "3f10254bSECRETKEY" not in msg
+    assert "Token" in msg  # scheme preserved for debuggability
+    assert "[REDACTED]" in msg
+
+
+def test_bearer_access_token_is_redacted(caplog):
+    install_websocket_log_redaction()
+    msg = _emit_header(caplog, "websockets.client", "Authorization", "bearer eyJ.SECRET.sig")
+    assert "SECRET" not in msg
+    assert msg.endswith("bearer [REDACTED]")
+
+
+def test_proxy_authorization_is_redacted(caplog):
+    install_websocket_log_redaction()
+    msg = _emit_header(caplog, "websockets.server", "Proxy-Authorization", "Basic c2VjcmV0")
+    assert "c2VjcmV0" not in msg
+    assert "[REDACTED]" in msg
+
+
+def test_non_sensitive_headers_are_untouched(caplog):
+    install_websocket_log_redaction()
+    msg = _emit_header(caplog, "websockets.client", "Sec-WebSocket-Version", "13")
+    assert msg == "> Sec-WebSocket-Version: 13"
+
+
+def test_redaction_is_case_insensitive_on_header_name(caplog):
+    install_websocket_log_redaction()
+    msg = _emit_header(caplog, "websockets.client", "authorization", "Token abc123")
+    assert "abc123" not in msg
+
+
+def test_without_install_secret_is_present(caplog):
+    """Sanity check: the secret IS logged when redaction is not installed."""
+    msg = _emit_header(caplog, "websockets.client", "Authorization", "Token VISIBLE123")
+    assert "VISIBLE123" in msg
+
+
+def test_install_is_idempotent():
+    install_websocket_log_redaction()
+    install_websocket_log_redaction()
+    for name in _WS_LOGGERS:
+        filters = [f for f in logging.getLogger(name).filters if isinstance(f, RedactCredentialsFilter)]
+        assert len(filters) == 1
+
+
+def test_uninstall_removes_filter():
+    install_websocket_log_redaction()
+    uninstall_websocket_log_redaction()
+    for name in _WS_LOGGERS:
+        filters = [f for f in logging.getLogger(name).filters if isinstance(f, RedactCredentialsFilter)]
+        assert filters == []
+
+
+def test_mask_value_preserves_scheme():
+    assert _mask_value("Token abc") == "Token [REDACTED]"
+    assert _mask_value("bearer xyz") == "bearer [REDACTED]"
+
+
+def test_mask_value_without_scheme_is_fully_masked():
+    assert _mask_value("rawsecret") == "[REDACTED]"
+
+
+def test_constructing_client_installs_redaction(caplog):
+    """The client constructor installs redaction by default."""
+    from deepgram import DeepgramClient
+
+    uninstall_websocket_log_redaction()
+    DeepgramClient(api_key="dummy-key")
+    msg = _emit_header(caplog, "websockets.client", "Authorization", "Token CTORSECRET")
+    assert "CTORSECRET" not in msg
+
+
+def test_opt_out_disables_redaction_at_construction(caplog):
+    """`redact_credentials_in_logs=False` leaves the websockets logs untouched."""
+    from deepgram import DeepgramClient
+
+    uninstall_websocket_log_redaction()
+    DeepgramClient(api_key="dummy-key", redact_credentials_in_logs=False)
+    # Constructor must not have installed the filter.
+    for name in _WS_LOGGERS:
+        filters = [f for f in logging.getLogger(name).filters if isinstance(f, RedactCredentialsFilter)]
+        assert filters == []


### PR DESCRIPTION
## Summary

Fixes an externally-reported security issue: the API key / access token is written to application logs in clear text when DEBUG logging is enabled.

The leak is **not** in Deepgram's code — it's the third-party `websockets` library, which logs the full opening handshake at DEBUG, one record per header, via `logger.debug("> %s: %s", name, value)`. That includes `Authorization: Token <key>`. Any app that turns on DEBUG (common in dev/troubleshooting) then writes the credential to its logs, from where it's easily committed or shipped to a log aggregator.

## Fix

Install a `logging.Filter` on the `websockets.client` / `websockets.server` loggers that masks the value of `Authorization` / `Proxy-Authorization` headers **before** the record reaches any handler — so the credential is never emitted, regardless of the app's log level.

- The auth scheme is preserved for debuggability; only the secret is replaced: `Authorization: Token [REDACTED]`.
- Nothing is suppressed and no other log output changes.
- **On by default** (installed from both client constructors, idempotent). Opt out with `DeepgramClient(redact_credentials_in_logs=False)` to manage redaction yourself.

Confirmed the filter reliably catches the record: `websockets >= 12` (our floor) emits handshake headers directly on `websockets.client` with no per-connection child loggers, so a filter there sees every header record before propagation.

## Files
- `src/deepgram/_secure_logging.py` — hand-written `RedactCredentialsFilter` + `install/uninstall` helpers (frozen in `.fernignore`)
- `src/deepgram/client.py` — install from `DeepgramClient` / `AsyncDeepgramClient` constructors + opt-out kwarg
- `tests/custom/test_secure_logging.py` — regression coverage (token masked, scheme preserved, non-sensitive headers untouched, idempotent install, opt-out)

## On the per-frame logging
The reporter also noted `BINARY ... [N bytes]` spam per audio frame. That's also `websockets` DEBUG output, but it contains **no secret** (payloads are shown only as byte counts), so it's a verbosity concern, not a disclosure. Silencing it by default would require raising the `websockets` logger level, which would also drop the handshake debug some users rely on. Recommended app-side mitigation (documented, not forced):

```python
import logging
logging.getLogger("websockets").setLevel(logging.INFO)  # quiet per-frame logs, keep your app at DEBUG
```

## Validation
- `ruff check` — clean
- `mypy` — clean
- `pytest` — 237 passed, 1 skipped (12 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)