### PR TITLE
fix: handle SSML phoneme attribute order in ssml_to_deepgram

### DIFF
--- a/src/deepgram/helpers/text_builder.py
+++ b/src/deepgram/helpers/text_builder.py
@@ -239,12 +239,18 @@ def ssml_to_deepgram(ssml_text: str) -> str:
     # Parse XML fragments manually to handle mixed content
     # Use regex to find and replace SSML elements
 
-    # Handle <phoneme> tags
-    phoneme_pattern = r'<phoneme\s+alphabet=["\']ipa["\']\s+ph=["\'](.*?)["\']\s*>(.*?)</phoneme>'
+    # Handle <phoneme> tags. Attribute order is not significant in SSML, so match
+    # the attributes as a group and pull `ph` out of it rather than requiring
+    # `alphabet` before `ph` (which silently dropped the pronunciation otherwise).
+    phoneme_pattern = r"<phoneme\s+([^>]*?)\s*>(.*?)</phoneme>"
 
     def replace_phoneme(match):
-        ipa = match.group(1)
+        attributes = match.group(1)
         word = match.group(2)
+        ph_match = re.search(r'ph=["\'](.*?)["\']', attributes)
+        if ph_match is None:
+            return word
+        ipa = ph_match.group(1)
         return json.dumps({"word": word, "pronounce": ipa}, ensure_ascii=False)
 
     ssml_text = re.sub(phoneme_pattern, replace_phoneme, ssml_text)

--- a/src/deepgram/helpers/text_builder.py
+++ b/src/deepgram/helpers/text_builder.py
@@ -247,10 +247,11 @@ def ssml_to_deepgram(ssml_text: str) -> str:
     def replace_phoneme(match):
         attributes = match.group(1)
         word = match.group(2)
-        ph_match = re.search(r'ph=["\'](.*?)["\']', attributes)
-        if ph_match is None:
+        alphabet_match = re.search(r'(?:^|\s)alphabet\s*=\s*(["\'])ipa\1(?=\s|$)', attributes)
+        ph_match = re.search(r'(?:^|\s)ph\s*=\s*(["\'])(.*?)\1(?=\s|$)', attributes)
+        if alphabet_match is None or ph_match is None:
             return word
-        ipa = ph_match.group(1)
+        ipa = ph_match.group(2)
         return json.dumps({"word": word, "pronounce": ipa}, ensure_ascii=False)
 
     ssml_text = re.sub(phoneme_pattern, replace_phoneme, ssml_text)

--- a/src/deepgram/helpers/text_builder.py
+++ b/src/deepgram/helpers/text_builder.py
@@ -242,7 +242,7 @@ def ssml_to_deepgram(ssml_text: str) -> str:
     # Handle <phoneme> tags. Attribute order is not significant in SSML, so match
     # the attributes as a group and pull `ph` out of it rather than requiring
     # `alphabet` before `ph` (which silently dropped the pronunciation otherwise).
-    phoneme_pattern = r"<phoneme\s+([^>]*?)\s*>(.*?)</phoneme>"
+    phoneme_pattern = r"<phoneme\s+([^<>]*?)\s*>([^<]*)</phoneme>"
 
     def replace_phoneme(match):
         attributes = match.group(1)

--- a/tests/custom/test_text_builder.py
+++ b/tests/custom/test_text_builder.py
@@ -234,10 +234,18 @@ class TestSsmlToDeepgram:
         """Test converting basic phoneme tag"""
         ssml = '<phoneme alphabet="ipa" ph="ˌæzəˈθaɪəpriːn">azathioprine</phoneme>'
         result = ssml_to_deepgram(ssml)
-        
+
         assert '"word": "azathioprine"' in result
         assert '"pronounce": "ˌæzəˈθaɪəpriːn"' in result
-    
+
+    def test_phoneme_attribute_order_independent(self):
+        """ph before alphabet must work too (SSML attribute order is not significant)"""
+        ssml = '<phoneme ph="ˌæzəˈθaɪəpriːn" alphabet="ipa">azathioprine</phoneme>'
+        result = ssml_to_deepgram(ssml)
+
+        assert '"word": "azathioprine"' in result
+        assert '"pronounce": "ˌæzəˈθaɪəpriːn"' in result
+
     def test_basic_break(self):
         """Test converting break tag (milliseconds)"""
         ssml = '<break time="500ms"/>'

--- a/tests/custom/test_text_builder.py
+++ b/tests/custom/test_text_builder.py
@@ -268,6 +268,18 @@ class TestSsmlToDeepgram:
 
         assert ssml_to_deepgram(ssml) == "medicine"
 
+    def test_unclosed_phoneme_does_not_consume_following_phoneme(self):
+        """Malformed input must not capture a later valid phoneme tag"""
+        ssml = (
+            '<phoneme alphabet="ipa" ph="bad">'
+            '<phoneme ph="good" alphabet="ipa">medicine</phoneme>'
+        )
+        result = ssml_to_deepgram(ssml)
+
+        assert '"word": "medicine"' in result
+        assert '"pronounce": "good"' in result
+        assert '"pronounce": "bad"' not in result
+
     def test_basic_break(self):
         """Test converting break tag (milliseconds)"""
         ssml = '<break time="500ms"/>'

--- a/tests/custom/test_text_builder.py
+++ b/tests/custom/test_text_builder.py
@@ -246,6 +246,28 @@ class TestSsmlToDeepgram:
         assert '"word": "azathioprine"' in result
         assert '"pronounce": "ˌæzəˈθaɪəpriːn"' in result
 
+    def test_phoneme_attributes_allow_whitespace_around_equals(self):
+        """Valid XML whitespace around attribute equals signs must be accepted"""
+        ssml = "<phoneme ph = 'ˌæzəˈθaɪəpriːn' alphabet = \"ipa\">azathioprine</phoneme>"
+        result = ssml_to_deepgram(ssml)
+
+        assert '"word": "azathioprine"' in result
+        assert '"pronounce": "ˌæzəˈθaɪəpriːn"' in result
+
+    @pytest.mark.parametrize(
+        "attributes",
+        [
+            'ph="test"',
+            'alphabet="x-sampa" ph="test"',
+            'alphabet="ipa" data-ph="test"',
+        ],
+    )
+    def test_phoneme_requires_ipa_alphabet_and_ph_attribute(self, attributes):
+        """Unsupported or lookalike attributes must degrade to plain text"""
+        ssml = f"<phoneme {attributes}>medicine</phoneme>"
+
+        assert ssml_to_deepgram(ssml) == "medicine"
+
     def test_basic_break(self):
         """Test converting break tag (milliseconds)"""
         ssml = '<break time="500ms"/>'
@@ -505,4 +527,3 @@ class TestIntegration:
         assert '"pronounce": "ˌæzəˈθaɪəpriːn"' in text
         assert '"word": "dupilumab"' in text
         assert '"pronounce": "duːˈpɪljuːmæb"' in text
-


### PR DESCRIPTION
## What

`ssml_to_deepgram()` only recognized `<phoneme>` tags when the attributes were in `alphabet`-before-`ph` order. Since [SSML attribute order is not significant](https://www.w3.org/TR/speech-synthesis11/), a perfectly valid tag written the other way was silently dropped:

```python
ssml_to_deepgram('<phoneme alphabet="ipa" ph="ˌæzə">azathioprine</phoneme>')
# -> {"word": "azathioprine", "pronounce": "ˌæzə"}   ✅

ssml_to_deepgram('<phoneme ph="ˌæzə" alphabet="ipa">azathioprine</phoneme>')
# -> "azathioprine"   ❌  pronunciation silently lost
```

The regex hardcoded `alphabet=... ph=...`; when reversed, the tag didn't match `phoneme_pattern` and fell through to the generic `<[^>]+>` strip, leaving only the bare word — no error, so the caller never knows the pronunciation was dropped.

## Fix

Match the `<phoneme>` attributes as a group and pull `ph` out of it, so order no longer matters (`src/deepgram/helpers/text_builder.py`). If there's no `ph` attribute, it degrades gracefully to the plain word. Behavior for the existing `alphabet`-first form is unchanged.

## Testing

Added `test_phoneme_attribute_order_independent` to `TestSsmlToDeepgram`. `pytest tests/custom/test_text_builder.py` → **45 passed**. Pure string transformation — no API key/network.