### PR TITLE
docs: iterate audio chunks in text-to-speech snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ response = client.speak.v1.audio.generate(
 
 # Save the audio file
 with open("output.mp3", "wb") as audio_file:
-    audio_file.write(response.stream.getvalue())
+    for chunk in response:
+        audio_file.write(chunk)
 ```
 
 #### Text Analysis

--- a/docs/Migrating-v3-to-v5.md
+++ b/docs/Migrating-v3-to-v5.md
@@ -316,7 +316,8 @@ response = client.speak.v1.audio.generate(
 
 # Save the audio file
 with open("output.mp3", "wb") as audio_file:
-    audio_file.write(response.stream.getvalue())
+    for chunk in response:
+        audio_file.write(chunk)
 ```
 
 #### WebSocket Streaming (Speak V1)


### PR DESCRIPTION
The text-to-speech snippet in the README called `response.stream.getvalue()`, but `client.speak.v1.audio.generate()` returns an `Iterator[bytes]`, so running it as written raises `AttributeError: 'generator' object has no attribute 'stream'`. I changed the snippet to iterate the response and write each chunk, and applied the same correction to the identical snippet in the v3 to v5 migration guide. Fixes #638.

I pushed this to my fork first and the project's own CI workflows pass on the commit.
