### PR TITLE
docs: clarify nova-3 transcription language defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ with client.listen.v2.connect(
 
 Transcribe pre-recorded audio files ([API Reference](./reference.md#listen-v1-media-transcribe-file)):
 
+`nova-3` assumes English when `language` is omitted. For non-English audio, pass the
+expected language explicitly (for example, `language="fr"`) or use `language="multi"`
+for automatic multilingual detection.
+
 ```python
 from deepgram import DeepgramClient
 
@@ -75,7 +79,8 @@ client = DeepgramClient()
 with open("audio.wav", "rb") as audio_file:
     response = client.listen.v1.media.transcribe_file(
         request=audio_file.read(),
-        model="nova-3"
+        model="nova-3",
+        language="en",
     )
     print(response.results.channels[0].alternatives[0].transcript)
 ```

--- a/README.md
+++ b/README.md
@@ -67,9 +67,10 @@ with client.listen.v2.connect(
 
 Transcribe pre-recorded audio files ([API Reference](./reference.md#listen-v1-media-transcribe-file)):
 
-`nova-3` assumes English when `language` is omitted. For non-English audio, pass the
-expected language explicitly (for example, `language="fr"`) or use `language="multi"`
-for automatic multilingual detection.
+`nova-3` uses English when `language` is omitted. For non-English audio, pass a
+supported language explicitly, such as `language="fr"`. Use `detect_language=True`
+when one dominant language is unknown, or `language="multi"` when the audio may
+contain multiple supported languages.
 
 ```python
 from deepgram import DeepgramClient


### PR DESCRIPTION
Closes #752

## Summary
- document that `nova-3` assumes English when `language` is omitted
- show an explicit `language="en"` value in the file-transcription quick-start
- point readers to an explicit language such as `fr` or `multi` for non-English and multilingual audio

## Verification
- `git diff --check`
- documentation-only change; no runtime code or dependencies modified