### PR TITLE
fix: preserve explicit API key semantics

### DIFF
--- a/src/deepgram/client.py
+++ b/src/deepgram/client.py
@@ -115,7 +115,7 @@ class DeepgramClient(BaseClient):
             # Set a placeholder api_key if none provided (base client requires it)
             if kwargs.get("api_key") is None:
                 kwargs["api_key"] = "token"
-        elif kwargs.get("api_key") is None:
+        elif "api_key" not in kwargs:
             # The generated base client takes os.getenv("DEEPGRAM_API_KEY") as a default
             # argument, so it is read once at import. Re-read it here so a key set after
             # import (load_dotenv below the imports) is still picked up.
@@ -199,7 +199,7 @@ class AsyncDeepgramClient(AsyncBaseClient):
             # Set a placeholder api_key if none provided (base client requires it)
             if kwargs.get("api_key") is None:
                 kwargs["api_key"] = "token"
-        elif kwargs.get("api_key") is None:
+        elif "api_key" not in kwargs:
             # The generated base client takes os.getenv("DEEPGRAM_API_KEY") as a default
             # argument, so it is read once at import. Re-read it here so a key set after
             # import (load_dotenv below the imports) is still picked up.

--- a/tests/custom/test_api_key_env_resolution.py
+++ b/tests/custom/test_api_key_env_resolution.py
@@ -8,6 +8,10 @@ client's re-read so the common ``load_dotenv()``-below-the-imports layout keeps
 working (issue #734).
 """
 
+import os
+import subprocess
+import sys
+import textwrap
 import typing
 
 import pytest
@@ -25,19 +29,45 @@ def _auth(client: typing.Any) -> typing.Optional[str]:
     return client._client_wrapper.api_key
 
 
-def test_env_key_set_after_import_is_used(
-    no_env_key: None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """The import already happened above with no key set; this is the load_dotenv case."""
-    monkeypatch.setenv("DEEPGRAM_API_KEY", "set-after-import")
-    assert _auth(DeepgramClient()) == "set-after-import"
-    assert _auth(AsyncDeepgramClient()) == "set-after-import"
+def test_env_key_set_after_import_is_used() -> None:
+    """Exercise the load_dotenv ordering in a process that starts without a key."""
+    env = os.environ.copy()
+    env.pop("DEEPGRAM_API_KEY", None)
+    code = textwrap.dedent(
+        """
+        import os
+
+        from deepgram import AsyncDeepgramClient, DeepgramClient
+
+        os.environ["DEEPGRAM_API_KEY"] = "set-after-import"
+        assert DeepgramClient()._client_wrapper.api_key == "set-after-import"
+        assert AsyncDeepgramClient()._client_wrapper.api_key == "set-after-import"
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_explicit_api_key_beats_the_environment(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("DEEPGRAM_API_KEY", "from-env")
     assert _auth(DeepgramClient(api_key="explicit")) == "explicit"
     assert _auth(AsyncDeepgramClient(api_key="explicit")) == "explicit"
+
+
+def test_explicit_none_does_not_fall_back_to_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DEEPGRAM_API_KEY", "from-env")
+    with pytest.raises(ApiError):
+        DeepgramClient(api_key=None)
+    with pytest.raises(ApiError):
+        AsyncDeepgramClient(api_key=None)
 
 
 def test_access_token_still_takes_precedence(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- resolve `DEEPGRAM_API_KEY` at construction only when the `api_key` argument is omitted
- preserve the existing behavior where explicit `api_key=None` rejects authentication instead of silently using an ambient process credential
- isolate the import-time environment regression in a subprocess that starts without `DEEPGRAM_API_KEY`
- add sync and async coverage for explicit-`None` behavior

Follow-up to #767 and #734.

## Why

#767 correctly fixed delayed environment loading, but its `kwargs.get("api_key") is None` check treated an omitted argument and explicit `None` as equivalent. In tests, multi-tenant services, or applications intentionally suppressing ambient authentication, explicit `None` must not activate a process-wide credential.

## Verification

- full Docker-backed suite: `1020 passed, 1 skipped`
- `mypy src`: clean across 901 source files
- Ruff: clean for both changed files
- seven-scenario sync/async credential probe: all passed
- regression tests proven non-vacuous against both the pre-#767 baseline and the original #767 implementation
- `git diff --check`: clean